### PR TITLE
Remove filter for VR device (3dRudder)

### DIFF
--- a/Scripts/Modules/DeviceInputModule.cs
+++ b/Scripts/Modules/DeviceInputModule.cs
@@ -67,7 +67,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             for (int i = 0; i < devices.Count; i++)
             {
                 var device = devices[i];
-                if (device is VRInputDevice && device.tagIndex != -1)
+                if (/*device is VRInputDevice && */device.tagIndex != -1)
                     m_SystemDevices.Add(device);
             }
 


### PR DESCRIPTION
I have one question:
* Is it possible to remove the ray on proxy? Because I have created a proxy for the 3dRudder device but the proxy created a ray and for the foot-controller it doesn't make sense. It's just a proxy for device that used a locomotion tool.