### PR TITLE
2018 compile fixes

### DIFF
--- a/Scripts/Utilities/AssetDropUtils.cs
+++ b/Scripts/Utilities/AssetDropUtils.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Video;
@@ -22,7 +23,7 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
         };
 
         // dependency types to ignore when previewing asset assignment validity
-        public static List<Type> ValidityOverrides = new List<Type>()
+        public static List<Type> AutoFillTypes = new List<Type>()
         {
             typeof(Animation), typeof(AudioSource), typeof(VideoPlayer)
         };
@@ -39,7 +40,6 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
         // TODO - make all these booleans options in the settings menu
         static bool m_CreatePlayerForClips = true;
         static bool m_AssignMultipleAnimationClips = true;
-        static bool m_InstanceMaterialOnShaderAssign = true;
 
         internal static void AssignAnimationClip(Animation animation, AnimationClip clipAsset)
         {
@@ -101,8 +101,12 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 
         internal static GameObject AttachScript(GameObject go, AssetData data)
         {
+            Debug.Log(data.asset);
             var script = (MonoScript)data.asset;
+            Debug.Log(script);
             var type = script.GetClass();
+            Debug.Log(type);
+
             Undo.AddComponent(go, type);
             return go;
         }
@@ -202,3 +206,4 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 
     }
 }
+#endif

--- a/Scripts/Utilities/ComponentUtils.cs
+++ b/Scripts/Utilities/ComponentUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Utilities
@@ -37,3 +38,5 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
         }
     }
 }
+
+#endif

--- a/Tests/Editor/BuildPlayerTest.cs
+++ b/Tests/Editor/BuildPlayerTest.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using UnityEngine;
+using NUnit.Framework;
 
 namespace UnityEditor.Experimental.EditorVR.Tests
 {
@@ -33,12 +34,26 @@ namespace UnityEditor.Experimental.EditorVR.Tests
 
         static void TestBuildPlayer(BuildTarget target)
         {
+#if UNITY_2018_1_OR_NEWER
             var output = BuildPipeline.BuildPlayer(EditorBuildSettings.scenes, "Temp/" + target, target, BuildOptions.BuildScriptsOnly);
 
+            if (output.steps.Length > 0)
+            {
+                foreach (var step in output.steps)
+                    foreach (var message in step.messages)
+                        if(message.content.Contains("target is not supported"))
+                            Assert.Inconclusive("Target platform {0} not installed", target);
+            }
+
+            Assert.AreEqual(0, output.summary.totalErrors);
+# elif UNITY_2017_1_OR_NEWER
+            string output = BuildPipeline.BuildPlayer(EditorBuildSettings.scenes, "Temp/" + target, target, BuildOptions.BuildScriptsOnly);
+            
             if (output.Contains("target is not supported"))
                 Assert.Inconclusive("Target platform {0} not installed", target);
 
             Assert.IsFalse(output.Contains("error"));
+#endif
         }
 
         [TearDown]


### PR DESCRIPTION
adds a few editor defines , one i missed during the last PR and one for ComponentUtils.

also fixes the BuildPlayer test to work in Unity 2018, using the new BuildReport object instead of a string.