### PR TITLE
Expand support for copying all enabled image effects on the main camera

### DIFF
--- a/Scripts/Core/Contexts/EditorVR.asset
+++ b/Scripts/Core/Contexts/EditorVR.asset
@@ -12,7 +12,8 @@ MonoBehaviour:
   m_Name: EditorVR
   m_EditorClassIdentifier: 
   m_RenderScale: 1
-  m_CopySceneCameraSettings: 1
+  m_CopyMainCameraSettings: 1
+  m_CopyMainCameraImageEffects: 1
   m_DefaultToolStack:
   - {fileID: 11500000, guid: 882053426a5f76d46b5505d9a20be912, type: 3}
   - {fileID: 11500000, guid: aab8fcc587f237c4cb48fb7bc8a59909, type: 3}

--- a/Scripts/Core/Contexts/EditorVRContext.cs
+++ b/Scripts/Core/Contexts/EditorVRContext.cs
@@ -14,14 +14,19 @@ namespace UnityEditor.Experimental.EditorVR.Core
         float m_RenderScale = 1f;
 
         [SerializeField]
-        bool m_CopyExistingCameraSettings = true;
+        bool m_CopyMainCameraSettings = true;
+
+        [SerializeField]
+        bool m_CopyMainCameraImageEffects;
 
         [SerializeField]
         internal List<MonoScript> m_DefaultToolStack;
 
         EditorVR m_Instance;
 
-        public bool copyExistingCameraSettings { get { return m_CopyExistingCameraSettings; } }
+        public bool copyMainCameraSettings { get { return m_CopyMainCameraSettings; } }
+
+        public bool copyMainCameraImageEffects { get { return m_CopyMainCameraImageEffects; } }
 
         public bool instanceExists { get { return m_Instance != null; } }
 

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -210,18 +210,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
                                 targetMethodFound = componentBaseType.GetMethod(targetMethodNames[i], bindingFlags) != null;
                         }
 
-                        // Check nested types for target methods
-                        if (!targetMethodFound)
-                        {
-                            var nestedTypes = componentInstanceType.GetNestedTypes();
-                            foreach (var nestedType in nestedTypes)
-                            {
-                                targetMethodFound = nestedType.GetMethod(targetMethodNames[i], bindingFlags) != null;
-                                if (targetMethodFound)
-                                    break;
-                            }
-                        }
-
                         if (targetMethodFound)
                             break;
                     }

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -145,7 +145,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
             s_ExistingSceneMainCamera = Camera.main;
             // TODO: Copy camera settings when changing contexts
-            if (EditingContextManager.defaultContext.copyExistingCameraSettings && s_ExistingSceneMainCamera && s_ExistingSceneMainCamera.enabled)
+            var defaultContext = EditingContextManager.defaultContext;
+            if (defaultContext.copyMainCameraSettings && s_ExistingSceneMainCamera && s_ExistingSceneMainCamera.enabled)
             {
                 GameObject cameraGO = EditorUtility.CreateGameObjectWithHideFlags(k_CameraName, HideFlags.HideAndDontSave);
                 m_Camera = ObjectUtils.CopyComponent(s_ExistingSceneMainCamera, cameraGO);
@@ -184,7 +185,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
             m_CameraRig.position = headCenteredOrigin;
             m_CameraRig.rotation = Quaternion.identity;
 
-            if (s_ExistingSceneMainCamera)
+            if (s_ExistingSceneMainCamera && defaultContext.copyMainCameraImageEffects)
             {
                 var cameraGameObject = m_Camera.gameObject;
                 var potentialImageEffects = s_ExistingSceneMainCamera.GetComponents<MonoBehaviour>();
@@ -197,8 +198,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
                     var targetMethodFound = false;
                     for (int i = 0; i < targetMethodNames.Length; ++i)
                     {
-                        // Each of the three checks is performed to catch the various image effect variants I've tested against
-                        // Each check catches a different case that was encountered during testing
                         // Check isntanced type for target methods
                         targetMethodFound = componentInstanceType.GetMethod(targetMethodNames[i], bindingFlags) != null;
 

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -216,9 +216,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
                             var nestedTypes = componentInstanceType.GetNestedTypes();
                             foreach (var nestedType in nestedTypes)
                             {
-                                if (nestedType == null)
-                                    continue;
-
                                 targetMethodFound = nestedType.GetMethod(targetMethodNames[i], bindingFlags) != null;
                                 if (targetMethodFound)
                                     break;

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -204,11 +204,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
                         // Check base type for target methods
                         if (!targetMethodFound)
-                        {
-                            var componentBaseType = componentInstanceType.BaseType;
-                            if (componentBaseType != null)
-                                targetMethodFound = componentBaseType.GetMethod(targetMethodNames[i], bindingFlags) != null;
-                        }
+                            targetMethodFound = ComponentUtils.MethodFoundInBaseType(componentInstanceType, targetMethodNames[i]);
 
                         if (targetMethodFound)
                             break;

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -190,7 +190,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
                 var potentialImageEffects = s_ExistingSceneMainCamera.GetComponents<MonoBehaviour>();
                 var enabledPotentialImageEffects = potentialImageEffects.Where(x => x != null && x.enabled);
                 var targetMethodNames = new [] {"OnRenderImage", "OnPreRender", "OnPostRender"};
-                var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+                var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
                 foreach (var potentialImageEffect in enabledPotentialImageEffects)
                 {
                     var componentInstanceType = potentialImageEffect.GetType();

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -229,19 +229,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
                             break;
                     }
 
+                    // Copying of certain image effects can cause Unity to crash when copied
                     if (targetMethodFound)
-                    {
-                        try
-                        {
-                            // During testing, some image effects caused Unity to crash when copied
-                            ObjectUtils.CopyComponent(potentialImageEffect, cameraGameObject);
-                        }
-                        catch (Exception e)
-                        {
-                            Console.WriteLine(e);
-                            throw;
-                        }
-                    }
+                        ObjectUtils.CopyComponent(potentialImageEffect, cameraGameObject);
                 }
 
                 s_ExistingSceneMainCameraEnabledState = s_ExistingSceneMainCamera.enabled;

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -198,12 +198,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
                     var targetMethodFound = false;
                     for (int i = 0; i < targetMethodNames.Length; ++i)
                     {
-                        // Check isntanced type for target methods
-                        targetMethodFound = componentInstanceType.GetMethod(targetMethodNames[i], bindingFlags) != null;
-
                         // Check base type for target methods
-                        if (!targetMethodFound)
-                            targetMethodFound = ComponentUtils.MethodFoundInBaseType(componentInstanceType, targetMethodNames[i]);
+                        targetMethodFound = componentInstanceType.GetMethodRecursively(targetMethodNames[i], bindingFlags) != null;
 
                         if (targetMethodFound)
                             break;

--- a/Scripts/Interfaces/Entity/IEditingContext.cs
+++ b/Scripts/Interfaces/Entity/IEditingContext.cs
@@ -15,9 +15,14 @@ namespace UnityEditor.Experimental.EditorVR
         string name { get; }
 
         /// <summary>
-        /// Bool denotes that the scene camera's (component) values should be cloned on the XR runtime camera
+        /// Bool denotes that the scene Main Camera (component) values should be cloned on the EditorXR runtime camera
         /// </summary>
-        bool copyExistingCameraSettings { get; }
+        bool copyMainCameraSettings { get; }
+
+        /// <summary>
+        /// Bool denotes that the scene's enabled Main Camera image effects should be cloned on the EditorXR runtime camera
+        /// </summary>
+        bool copyMainCameraImageEffects { get; }
 
         /// <summary>
         /// Bool denotes that the EditorVR instance exists, having already been created in Setup()

--- a/Scripts/Utilities/ComponentUtils.cs
+++ b/Scripts/Utilities/ComponentUtils.cs
@@ -39,14 +39,17 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
             return component;
         }
 
-        public static bool MethodFoundInBaseType(Type type, string methodName, BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+        public static MethodInfo GetMethodRecursively(this Type type, string name, BindingFlags bindingAttr)
         {
-            var methodFound = false;
-            var componentBaseType = type.BaseType;
-            if (componentBaseType != null)
-                methodFound = componentBaseType.GetMethod(methodName, bindingFlags) != null;
+            var method = type.GetMethod(name, bindingAttr);
+            if (method != null)
+                return method;
 
-            return methodFound;
+            var baseType = type.BaseType;
+            if (baseType != null)
+                method = type.BaseType.GetMethodRecursively(name, bindingAttr);
+
+            return method;
         }
     }
 }

--- a/Scripts/Utilities/ComponentUtils.cs
+++ b/Scripts/Utilities/ComponentUtils.cs
@@ -1,5 +1,7 @@
 ﻿#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
+using System.Reflection;
 using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Utilities
@@ -36,7 +38,16 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 
             return component;
         }
+
+        public static bool MethodFoundInBaseType(Type type, string methodName, BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+        {
+            var methodFound = false;
+            var componentBaseType = type.BaseType;
+            if (componentBaseType != null)
+                methodFound = componentBaseType.GetMethod(methodName, bindingFlags) != null;
+
+            return methodFound;
+        }
     }
 }
-
 #endif


### PR DESCRIPTION
**Purpose of this PR**
This improvement adds support for copying all _enabled_ images effects on the _Main_ Camera, to EditorXR's VRCamera.  Previously, only the V1 post processing stack was supported.

**Testing status**
Tested using the V1 post processing stack, the V2 post processing stack, and a small assortment of Asset Store image effects.  Tested with both single, and multi-effect copying.

**Technical risk**
Low - This more generalized approach to detecting & copying potential image effects has revealed an issue that occurs when copying certain image effects.  One of the effects I tested against caused Unity to crash every time (Amplify Occlusion).  Though, all others copied as intended, and performed well (aside from the viewer scale issue I describe below).

**Notes**
When performing viewer scaling, there can be artifacts visually present in certain image effects.  Such effects should be re-written to support realtime viewer scaling.  For example, ambient occlusion in the V1 stack presents some visual artifacts when scaling, whereas V2 doesn't.  We should consider adding a rotation-only toggle to viewer scale, in order to alleviate the issue for the image effects that will not add such support, or due to the nature of the effect, cannot add such support without a performance penalty.

**_EDIT_**
To handle for potential image effect copy crashes, or a case in which you still want the camera settings copied, but not the enabled image effects, I added a new corresponding inspector bool/checkbox to EditorXR editing contexts. If set to TRUE on an EditorXR context, enabled image effects on the Main Camera will be copied. 