### PR TITLE
Add selective support for copying enabled image effects to the presentation camera

### DIFF
--- a/Scripts/Core/Contexts/EditorVR.asset
+++ b/Scripts/Core/Contexts/EditorVR.asset
@@ -13,7 +13,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_RenderScale: 1
   m_CopyMainCameraSettings: 1
-  m_CopyMainCameraImageEffects: 1
+  m_CopyMainCameraImageEffectsToHmd: 1
+  m_CopyMainCameraImageEffectsToPresentationCamera: 1
   m_DefaultToolStack:
   - {fileID: 11500000, guid: 882053426a5f76d46b5505d9a20be912, type: 3}
   - {fileID: 11500000, guid: aab8fcc587f237c4cb48fb7bc8a59909, type: 3}

--- a/Scripts/Core/Contexts/EditorVR.asset
+++ b/Scripts/Core/Contexts/EditorVR.asset
@@ -12,7 +12,8 @@ MonoBehaviour:
   m_Name: EditorVR
   m_EditorClassIdentifier: 
   m_RenderScale: 1
-  m_CopySceneCameraSettings: 1
+  m_CopyMainCameraSettings: 1
+  m_CopyMainCameraImageEffects: 1
   m_DefaultToolStack:
   - {fileID: 11500000, guid: 882053426a5f76d46b5505d9a20be912, type: 3}
   - {fileID: 11500000, guid: aab8fcc587f237c4cb48fb7bc8a59909, type: 3}

--- a/Scripts/Core/Contexts/EditorVRContext.cs
+++ b/Scripts/Core/Contexts/EditorVRContext.cs
@@ -14,14 +14,19 @@ namespace UnityEditor.Experimental.EditorVR.Core
         float m_RenderScale = 1f;
 
         [SerializeField]
-        bool m_CopyExistingCameraSettings = true;
+        bool m_CopyMainCameraSettings = true;
+
+        [SerializeField]
+        bool m_CopyMainCameraImageEffects;
 
         [SerializeField]
         internal List<MonoScript> m_DefaultToolStack;
 
         EditorVR m_Instance;
 
-        public bool copyExistingCameraSettings { get { return m_CopyExistingCameraSettings; } }
+        public bool copyMainCameraSettings { get { return m_CopyMainCameraSettings; } }
+
+        public bool copyMainCameraImageEffects { get { return m_CopyMainCameraImageEffects; } }
 
         public bool instanceExists { get { return m_Instance != null; } }
 

--- a/Scripts/Core/Contexts/EditorVRContext.cs
+++ b/Scripts/Core/Contexts/EditorVRContext.cs
@@ -17,7 +17,10 @@ namespace UnityEditor.Experimental.EditorVR.Core
         bool m_CopyMainCameraSettings = true;
 
         [SerializeField]
-        bool m_CopyMainCameraImageEffects;
+        bool m_CopyMainCameraImageEffectsToHmd;
+
+        [SerializeField]
+        bool m_CopyMainCameraImageEffectsToPresentationCamera;
 
         [SerializeField]
         internal List<MonoScript> m_DefaultToolStack;
@@ -26,7 +29,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
         public bool copyMainCameraSettings { get { return m_CopyMainCameraSettings; } }
 
-        public bool copyMainCameraImageEffects { get { return m_CopyMainCameraImageEffects; } }
+        public bool copyMainCameraImageEffectsToHMD { get { return m_CopyMainCameraImageEffectsToHmd; } }
+
+        public bool copyMainCameraImageEffectsToPresentationCamera { get { return m_CopyMainCameraImageEffectsToPresentationCamera; } }
 
         public bool instanceExists { get { return m_Instance != null; } }
 

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -210,18 +210,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
                                 targetMethodFound = componentBaseType.GetMethod(targetMethodNames[i], bindingFlags) != null;
                         }
 
-                        // Check nested types for target methods
-                        if (!targetMethodFound)
-                        {
-                            var nestedTypes = componentInstanceType.GetNestedTypes();
-                            foreach (var nestedType in nestedTypes)
-                            {
-                                targetMethodFound = nestedType.GetMethod(targetMethodNames[i], bindingFlags) != null;
-                                if (targetMethodFound)
-                                    break;
-                            }
-                        }
-
                         if (targetMethodFound)
                             break;
                     }

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -145,7 +145,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
             s_ExistingSceneMainCamera = Camera.main;
             // TODO: Copy camera settings when changing contexts
-            if (EditingContextManager.defaultContext.copyExistingCameraSettings && s_ExistingSceneMainCamera && s_ExistingSceneMainCamera.enabled)
+            var defaultContext = EditingContextManager.defaultContext;
+            if (defaultContext.copyMainCameraSettings && s_ExistingSceneMainCamera && s_ExistingSceneMainCamera.enabled)
             {
                 GameObject cameraGO = EditorUtility.CreateGameObjectWithHideFlags(k_CameraName, HideFlags.HideAndDontSave);
                 m_Camera = ObjectUtils.CopyComponent(s_ExistingSceneMainCamera, cameraGO);
@@ -184,7 +185,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
             m_CameraRig.position = headCenteredOrigin;
             m_CameraRig.rotation = Quaternion.identity;
 
-            if (s_ExistingSceneMainCamera)
+            if (s_ExistingSceneMainCamera && defaultContext.copyMainCameraImageEffects)
             {
                 var cameraGameObject = m_Camera.gameObject;
                 var potentialImageEffects = s_ExistingSceneMainCamera.GetComponents<MonoBehaviour>();
@@ -197,8 +198,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
                     var targetMethodFound = false;
                     for (int i = 0; i < targetMethodNames.Length; ++i)
                     {
-                        // Each of the three checks is performed to catch the various image effect variants I've tested against
-                        // Each check catches a different case that was encountered during testing
                         // Check isntanced type for target methods
                         targetMethodFound = componentInstanceType.GetMethod(targetMethodNames[i], bindingFlags) != null;
 

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -216,9 +216,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
                             var nestedTypes = componentInstanceType.GetNestedTypes();
                             foreach (var nestedType in nestedTypes)
                             {
-                                if (nestedType == null)
-                                    continue;
-
                                 targetMethodFound = nestedType.GetMethod(targetMethodNames[i], bindingFlags) != null;
                                 if (targetMethodFound)
                                     break;

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -34,9 +34,10 @@ namespace UnityEditor.Experimental.EditorVR.Core
             {
                 if (s_ActiveView)
                 {
-                    s_ActiveView.m_CustomPreviewCamera = value;
-                    if (EditingContextManager.defaultContext.copyMainCameraImageEffectsToPresentationCamera)
+                    if (!s_ActiveView.m_CustomPreviewCamera && EditingContextManager.defaultContext.copyMainCameraImageEffectsToPresentationCamera)
                         CopyImagesEffectsToCamera(value);
+
+                    s_ActiveView.m_CustomPreviewCamera = value;
                 }
             }
             get

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -204,11 +204,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
                         // Check base type for target methods
                         if (!targetMethodFound)
-                        {
-                            var componentBaseType = componentInstanceType.BaseType;
-                            if (componentBaseType != null)
-                                targetMethodFound = componentBaseType.GetMethod(targetMethodNames[i], bindingFlags) != null;
-                        }
+                            targetMethodFound = ComponentUtils.MethodFoundInBaseType(componentInstanceType, targetMethodNames[i]);
 
                         if (targetMethodFound)
                             break;

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -190,7 +190,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
                 var potentialImageEffects = s_ExistingSceneMainCamera.GetComponents<MonoBehaviour>();
                 var enabledPotentialImageEffects = potentialImageEffects.Where(x => x != null && x.enabled);
                 var targetMethodNames = new [] {"OnRenderImage", "OnPreRender", "OnPostRender"};
-                var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+                var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
                 foreach (var potentialImageEffect in enabledPotentialImageEffects)
                 {
                     var componentInstanceType = potentialImageEffect.GetType();

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -33,7 +33,11 @@ namespace UnityEditor.Experimental.EditorVR.Core
             set
             {
                 if (s_ActiveView)
+                {
                     s_ActiveView.m_CustomPreviewCamera = value;
+                    if (EditingContextManager.defaultContext.copyMainCameraImageEffectsToPresentationCamera)
+                        CopyImagesEffectsToCamera(value);
+                }
             }
             get
             {
@@ -185,34 +189,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
             m_CameraRig.position = headCenteredOrigin;
             m_CameraRig.rotation = Quaternion.identity;
 
-            if (s_ExistingSceneMainCamera && defaultContext.copyMainCameraImageEffects)
+            if (s_ExistingSceneMainCamera && defaultContext.copyMainCameraImageEffectsToHMD)
             {
-                var cameraGameObject = m_Camera.gameObject;
-                var potentialImageEffects = s_ExistingSceneMainCamera.GetComponents<MonoBehaviour>();
-                var enabledPotentialImageEffects = potentialImageEffects.Where(x => x != null && x.enabled);
-                var targetMethodNames = new [] {"OnRenderImage", "OnPreRender", "OnPostRender"};
-                var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
-                foreach (var potentialImageEffect in enabledPotentialImageEffects)
-                {
-                    var componentInstanceType = potentialImageEffect.GetType();
-                    var targetMethodFound = false;
-                    for (int i = 0; i < targetMethodNames.Length; ++i)
-                    {
-                        // Check isntanced type for target methods
-                        targetMethodFound = componentInstanceType.GetMethod(targetMethodNames[i], bindingFlags) != null;
-
-                        // Check base type for target methods
-                        if (!targetMethodFound)
-                            targetMethodFound = ComponentUtils.MethodFoundInBaseType(componentInstanceType, targetMethodNames[i]);
-
-                        if (targetMethodFound)
-                            break;
-                    }
-
-                    // Copying of certain image effects can cause Unity to crash when copied
-                    if (targetMethodFound)
-                        ObjectUtils.CopyComponent(potentialImageEffect, cameraGameObject);
-                }
+                CopyImagesEffectsToCamera(m_Camera);
 
                 s_ExistingSceneMainCameraEnabledState = s_ExistingSceneMainCamera.enabled;
                 s_ExistingSceneMainCamera.enabled = false; // Disable existing MainCamera in the scene
@@ -234,6 +213,37 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
             if (viewEnabled != null)
                 viewEnabled();
+        }
+
+        static void CopyImagesEffectsToCamera(Camera targetCamera)
+        {
+            var targetCameraGO = targetCamera.gameObject;
+            var potentialImageEffects = s_ExistingSceneMainCamera.GetComponents<MonoBehaviour>();
+            var enabledPotentialImageEffects = potentialImageEffects.Where(x => x != null && x.enabled);
+            var targetMethodNames = new [] {"OnRenderImage", "OnPreRender", "OnPostRender"};
+            var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            foreach (var potentialImageEffect in enabledPotentialImageEffects)
+            {
+                var componentInstanceType = potentialImageEffect.GetType();
+                var targetMethodFound = false;
+                for (int i = 0; i < targetMethodNames.Length; ++i)
+                {
+                    // Check isntanced type for target methods
+                    targetMethodFound = componentInstanceType.GetMethod(targetMethodNames[i], bindingFlags) != null;
+
+                    // Check base type for target methods
+                    if (!targetMethodFound)
+                        targetMethodFound =
+                            ComponentUtils.MethodFoundInBaseType(componentInstanceType, targetMethodNames[i]);
+
+                    if (targetMethodFound)
+                        break;
+                }
+
+                // Copying of certain image effects can cause Unity to crash when copied
+                if (targetMethodFound)
+                    ObjectUtils.CopyComponent(potentialImageEffect, targetCameraGO);
+            }
         }
 
         public void OnDisable()

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -229,19 +229,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
                             break;
                     }
 
+                    // Copying of certain image effects can cause Unity to crash when copied
                     if (targetMethodFound)
-                    {
-                        try
-                        {
-                            // During testing, some image effects caused Unity to crash when copied
-                            ObjectUtils.CopyComponent(potentialImageEffect, cameraGameObject);
-                        }
-                        catch (Exception e)
-                        {
-                            Console.WriteLine(e);
-                            throw;
-                        }
-                    }
+                        ObjectUtils.CopyComponent(potentialImageEffect, cameraGameObject);
                 }
 
                 s_ExistingSceneMainCameraEnabledState = s_ExistingSceneMainCamera.enabled;

--- a/Scripts/Interfaces/Entity/IEditingContext.cs
+++ b/Scripts/Interfaces/Entity/IEditingContext.cs
@@ -20,9 +20,14 @@ namespace UnityEditor.Experimental.EditorVR
         bool copyMainCameraSettings { get; }
 
         /// <summary>
-        /// Bool denotes that the scene's enabled Main Camera image effects should be cloned on the EditorXR runtime camera
+        /// Bool denotes that the scene's enabled Main Camera image effects should be cloned on the EditorXR HMD camera
         /// </summary>
-        bool copyMainCameraImageEffects { get; }
+        bool copyMainCameraImageEffectsToHMD { get; }
+
+        /// <summary>
+        /// Bool denotes that the scene's enabled Main Camera image effects should be cloned on the EditorXR presentation camera
+        /// </summary>
+        bool copyMainCameraImageEffectsToPresentationCamera { get; }
 
         /// <summary>
         /// Bool denotes that the EditorVR instance exists, having already been created in Setup()

--- a/Scripts/Interfaces/Entity/IEditingContext.cs
+++ b/Scripts/Interfaces/Entity/IEditingContext.cs
@@ -15,9 +15,14 @@ namespace UnityEditor.Experimental.EditorVR
         string name { get; }
 
         /// <summary>
-        /// Bool denotes that the scene camera's (component) values should be cloned on the XR runtime camera
+        /// Bool denotes that the scene Main Camera (component) values should be cloned on the EditorXR runtime camera
         /// </summary>
-        bool copyExistingCameraSettings { get; }
+        bool copyMainCameraSettings { get; }
+
+        /// <summary>
+        /// Bool denotes that the scene's enabled Main Camera image effects should be cloned on the EditorXR runtime camera
+        /// </summary>
+        bool copyMainCameraImageEffects { get; }
 
         /// <summary>
         /// Bool denotes that the EditorVR instance exists, having already been created in Setup()

--- a/Scripts/Utilities/ComponentUtils.cs
+++ b/Scripts/Utilities/ComponentUtils.cs
@@ -1,5 +1,7 @@
 ﻿#if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
+using System.Reflection;
 using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Utilities
@@ -36,7 +38,16 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
 
             return component;
         }
+
+        public static bool MethodFoundInBaseType(Type type, string methodName, BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+        {
+            var methodFound = false;
+            var componentBaseType = type.BaseType;
+            if (componentBaseType != null)
+                methodFound = componentBaseType.GetMethod(methodName, bindingFlags) != null;
+
+            return methodFound;
+        }
     }
 }
-
 #endif


### PR DESCRIPTION
**Purpose of this PR**
Add support for copying Main Camera image effects to the presentation camera (separate from the HMD).  A new inspector bool was added to EXR contexts, in order to selectively enable/disable this functionality for either/both the HMD & presentation camera.

The below fields/properties have been added to EditorXR contexts:
_copyMainCameraImageEffectsToHMD_
_copyMainCameraImageEffectsToPresentationCamera_

**Testing status**
Tested using many different post processing image effects.  Tested with both single, and multi-effect copying.

**Technical risk**
Low - Aside from "Amplify Occlusion", I found no issues during testing.  All effects copied to their intended camera, and performed as expected (aside from the viewer scale issue I describe below).

**Notes**
When performing viewer scaling, there can be artifacts visually present in certain image effects. Such effects should be re-written to support realtime viewer scaling. For example, ambient occlusion in the V1 stack presents some visual artifacts when scaling, whereas V2 doesn't. We should consider adding a rotation-only toggle to viewer scale, in order to alleviate the issue for the image effects that will not add such support, or due to the nature of the effect, cannot add such support without a performance penalty.