### PR TITLE
Add smooth rotational lerping of the floor/foot-level object

### DIFF
--- a/Scripts/Helpers/PlayerFloor.cs
+++ b/Scripts/Helpers/PlayerFloor.cs
@@ -9,9 +9,15 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
     [ExecuteInEditMode]
     public class PlayerFloor : MonoBehaviour, IUsesViewerScale
     {
-        Vector3 m_floorPosition;
+        const float k_XOffset = 0.05f;
+        const float k_ZOffset = 0.2f;
+
+        Vector3 m_FloorPosition;
         Transform m_Camera;
         Transform m_CameraRig;
+
+        Vector3 m_CameraForwardCurrent;
+        Vector3 m_CameraForwardTarget;
 
         void Awake()
         {
@@ -19,19 +25,19 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
             m_CameraRig = CameraUtils.GetCameraRig();
         }
 
-        const float xOffset = 0.05f;
-        const float zOffset = 0.2f;
-        var currentScale = this.GetViewerScale();
         void Update()
         {
-            m_floorPosition.x = m_Camera.position.x + xOffset * currentScale;
-            m_floorPosition.z = m_Camera.position.z - zOffset * currentScale;
-            m_floorPosition.y = m_CameraRig.transform.position.y;
-            m_floorPosition -= VRView.headCenteredOrigin * currentScale;
-            transform.position = m_floorPosition;
-            transform.forward = m_Camera.transform.XZForward();
+            const float kLerpMultiplier = 4f;
+            var currentScale = this.GetViewerScale();
+            m_FloorPosition.x = m_Camera.position.x + k_XOffset * currentScale;
+            m_FloorPosition.z = m_Camera.position.z - k_ZOffset * currentScale;
+            m_FloorPosition.y = m_CameraRig.transform.position.y;
+            m_FloorPosition -= VRView.headCenteredOrigin * currentScale;
+            transform.position = m_FloorPosition;
+            m_CameraForwardTarget = m_Camera.transform.XZForward();
+            m_CameraForwardCurrent = Vector3.Lerp(m_CameraForwardCurrent, m_CameraForwardTarget, Time.unscaledDeltaTime * kLerpMultiplier);
+            transform.forward = m_CameraForwardCurrent;
         }
     }
-
 }
 #endif


### PR DESCRIPTION
### Purpose of this PR
Add smooth rotational lerping of the foot indicator.  This PR also addresses some naming/convention issues as well.   Also fixes various gimbal-flip-like artifacts I ran into during testing of the base-branch.

### Testing status
Tested in various scenes.

### Technical risk
Low. Only adding smoothing of rotation to a transform.