### PR TITLE
Adding gaze divergence module

### DIFF
--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -240,6 +240,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
             };
 
             AddModule<HapticsModule>();
+            AddModule<GazeDivergenceModule>();
             AddModule<SpatialHintModule>();
             AddModule<SpatialScrollModule>();
 

--- a/Scripts/Core/InterfaceConnectors/GazeDivergenceModuleConnector.cs
+++ b/Scripts/Core/InterfaceConnectors/GazeDivergenceModuleConnector.cs
@@ -1,0 +1,17 @@
+﻿#if UNITY_EDITOR
+using UnityEditor.Experimental.EditorVR.Modules;
+
+namespace UnityEditor.Experimental.EditorVR.Core
+{
+    partial class EditorVR
+    {
+        class GazeDivergenceModuleConnector : Nested, ILateBindInterfaceMethods<GazeDivergenceModule>
+        {
+            public void LateBindInterfaceMethods(GazeDivergenceModule provider)
+            {
+                IDetectGazeDivergenceMethods.isAboveDivergenceThreshold = provider.IsAboveDivergenceThreshold;
+            }
+        }
+    }
+}
+#endif

--- a/Scripts/Core/InterfaceConnectors/GazeDivergenceModuleConnector.cs.meta
+++ b/Scripts/Core/InterfaceConnectors/GazeDivergenceModuleConnector.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3642bf2ab8b249f4f99c0cea278da6ab
+timeCreated: 1489520545
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Interfaces/FunctionalityInjection/IDetectGazeDivergence.cs
+++ b/Scripts/Interfaces/FunctionalityInjection/IDetectGazeDivergence.cs
@@ -1,0 +1,26 @@
+﻿#if UNITY_EDITOR
+using System;
+using UnityEngine;
+
+namespace UnityEditor.Experimental.EditorVR
+{
+    /// <summary>
+    /// Gives decorated class ability to detect gaze divergence above a defined threshold, for a given transform's forward vector
+    /// </summary>
+    public interface IDetectGazeDivergence
+    {
+    }
+
+    public static class IDetectGazeDivergenceMethods
+    {
+        internal delegate bool IsAboveDivergenceThresholdDelegate(IDetectGazeDivergence obj, Transform transformToTest, float divergenceThreshold, bool disregardTemporalStability = true);
+
+        internal static Func<Transform, float, bool, bool> isAboveDivergenceThreshold { private get; set; }
+
+        public static bool IsAboveDivergenceThreshold(this IDetectGazeDivergence obj, Transform transformToTest, float divergenceThreshold, bool disregardTemporalStability = true)
+        {
+            return isAboveDivergenceThreshold(transformToTest, divergenceThreshold, disregardTemporalStability);
+        }
+    }
+}
+#endif

--- a/Scripts/Interfaces/FunctionalityInjection/IDetectGazeDivergence.cs.meta
+++ b/Scripts/Interfaces/FunctionalityInjection/IDetectGazeDivergence.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a57eee7c723d3604bab0e0e93c4aefce
+timeCreated: 1468885156
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Modules/GazeDivergenceModule.meta
+++ b/Scripts/Modules/GazeDivergenceModule.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: bd7efe5d6c26820488606f0ffd99b30a
+folderAsset: yes
+timeCreated: 1518820806
+licenseType: Pro
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Modules/GazeDivergenceModule/GazeDivergenceModule.cs
+++ b/Scripts/Modules/GazeDivergenceModule/GazeDivergenceModule.cs
@@ -33,7 +33,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             var gazeRotationDifference = Quaternion.Angle(currentGazeSourceRotation, m_PreviousGazeRotation);
             gazeRotationDifference *= gazeRotationDifference; // Square the difference for intended response curve/shape
             m_GazeVelocity = m_GazeVelocity + gazeRotationDifference * Time.unscaledDeltaTime;
-            m_GazeVelocity = Mathf.Clamp01(m_GazeVelocity -= Time.unscaledDeltaTime);
+            m_GazeVelocity = Mathf.Clamp01(m_GazeVelocity - Time.unscaledDeltaTime);
             m_PreviousGazeRotation = currentGazeSourceRotation; // Cache the previous camera rotation
         }
 

--- a/Scripts/Modules/GazeDivergenceModule/GazeDivergenceModule.cs
+++ b/Scripts/Modules/GazeDivergenceModule/GazeDivergenceModule.cs
@@ -1,0 +1,56 @@
+﻿#if UNITY_EDITOR
+using UnityEditor.Experimental.EditorVR.Utilities;
+using UnityEngine;
+
+namespace UnityEditor.Experimental.EditorVR.Modules
+{
+    public sealed class GazeDivergenceModule : MonoBehaviour
+    {
+        const float k_StableGazeThreshold = 0.25f;
+
+        Transform m_GazeSourceTransform;
+        Quaternion m_PreviousGazeRotation;
+        float m_GazeVelocity;
+
+        public bool gazeStable { get { return m_GazeVelocity < k_StableGazeThreshold; } }
+
+        void Awake()
+        {
+            m_GazeSourceTransform = CameraUtils.GetMainCamera().transform;
+        }
+
+        void Update()
+        {
+            var gazeRotationDifference = Quaternion.Angle(m_GazeSourceTransform.rotation, m_PreviousGazeRotation);
+            gazeRotationDifference *= gazeRotationDifference; // Square the difference for intended response curve/shape
+            m_GazeVelocity = m_GazeVelocity + gazeRotationDifference * Time.unscaledDeltaTime;
+            m_GazeVelocity = Mathf.Clamp01(m_GazeVelocity -= Time.unscaledDeltaTime);
+            m_PreviousGazeRotation = m_GazeSourceTransform.rotation; // Cache the previous camera rotation
+        }
+
+        /// <summary>
+        /// Test for a transform residing with a defined angular divergence threshold
+        /// </summary>
+        /// <param name="objectToTest">Vector to test for a threshold cross with relation to the gazeSource forward vector</param>
+        /// <param name="divergenceThreshold">Threshold, in degrees, via doc product conversion of this angular value</param>
+        /// <param name="disregardTemporalStability">If true, mandate that divergence detection occur, regardless of the gaze being stable</param>
+        /// <returns>True if the object is beyond the divergence threshold, False if it is within the defined range</returns>
+        public bool IsAboveDivergenceThreshold(Transform objectToTest, float divergenceThreshold, bool disregardTemporalStability = true)
+        {
+            var isAbove = false;
+            if (disregardTemporalStability || gazeStable) // validate that the gaze is stable if disregarding temporal stability
+            {
+                var gazeDirection = m_GazeSourceTransform.forward;
+                var testVector = objectToTest.position - m_GazeSourceTransform.position; // Test object to gaze source vector
+                testVector.Normalize(); // Normalize, in order to retain expected dot values
+
+                var divergenceThresholdConvertedToDot = Mathf.Sin(Mathf.Deg2Rad * divergenceThreshold);
+                var angularComparison = Mathf.Abs(Vector3.Dot(testVector, gazeDirection));
+                isAbove = angularComparison < divergenceThresholdConvertedToDot;
+            }
+
+            return isAbove;
+        }
+    }
+}
+#endif

--- a/Scripts/Modules/GazeDivergenceModule/GazeDivergenceModule.cs
+++ b/Scripts/Modules/GazeDivergenceModule/GazeDivergenceModule.cs
@@ -4,6 +4,10 @@ using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Modules
 {
+    /// <summary>
+    /// Allows an implementer to test for a given transforms'
+    /// position residing within an angular threshold of the HMD
+    /// </summary>
     public sealed class GazeDivergenceModule : MonoBehaviour
     {
         const float k_StableGazeThreshold = 0.25f;
@@ -12,20 +16,25 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         Quaternion m_PreviousGazeRotation;
         float m_GazeVelocity;
 
+        /// <summary>
+        /// Is the gaze currently focused on a single location, and not scanning the surrounding FOV above a certain velocity
+        /// </summary>
         public bool gazeStable { get { return m_GazeVelocity < k_StableGazeThreshold; } }
 
         void Awake()
         {
             m_GazeSourceTransform = CameraUtils.GetMainCamera().transform;
+            m_PreviousGazeRotation = m_GazeSourceTransform.rotation; // Prevent a quick initial snap of interpolated rotation values
         }
 
         void Update()
         {
-            var gazeRotationDifference = Quaternion.Angle(m_GazeSourceTransform.rotation, m_PreviousGazeRotation);
+            var currentGazeSourceRotation = m_GazeSourceTransform.rotation;
+            var gazeRotationDifference = Quaternion.Angle(currentGazeSourceRotation, m_PreviousGazeRotation);
             gazeRotationDifference *= gazeRotationDifference; // Square the difference for intended response curve/shape
             m_GazeVelocity = m_GazeVelocity + gazeRotationDifference * Time.unscaledDeltaTime;
             m_GazeVelocity = Mathf.Clamp01(m_GazeVelocity -= Time.unscaledDeltaTime);
-            m_PreviousGazeRotation = m_GazeSourceTransform.rotation; // Cache the previous camera rotation
+            m_PreviousGazeRotation = currentGazeSourceRotation; // Cache the previous camera rotation
         }
 
         /// <summary>

--- a/Scripts/Modules/GazeDivergenceModule/GazeDivergenceModule.cs.meta
+++ b/Scripts/Modules/GazeDivergenceModule/GazeDivergenceModule.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 405d78cc17a0e9c46af1b4cc4e2a26dc
+timeCreated: 1518206945
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR
Add functionality to any implementer, allowing them to detect when the HMD is focused upon a given transform, within a defined (degree-based)range.

The "foot-indicator-smooth-opacity" branch utilizes this module, in order to fade the PlayerFloor UI contents in/out, according to when they're being focused upon.

### Testing status
Tested in various scenes & conditions.  I haven't encountered issues with the addition of this Module.

### Technical risk
Low.  Outside of the addition of the module registration in EditorVR.cs, there's not much room for this code to cause conflicts.

### Comments to reviewers
The module's functionality can be tested with the "foot-indicator-smooth-opacity" branch (still in progress).