### PR TITLE
Fix image-effect copy exception

### DIFF
--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -34,7 +34,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
             {
                 if (s_ActiveView)
                 {
-                    if (!s_ActiveView.m_CustomPreviewCamera && EditingContextManager.defaultContext.copyMainCameraImageEffectsToPresentationCamera)
+                    if (s_ExistingSceneMainCamera && !s_ActiveView.m_CustomPreviewCamera && EditingContextManager.defaultContext.copyMainCameraImageEffectsToPresentationCamera)
                         CopyImagesEffectsToCamera(value);
 
                     s_ActiveView.m_CustomPreviewCamera = value;


### PR DESCRIPTION
### Purpose of this PR
Fix exception thrown in scenes whose MainCamera isn't tagged as "MainCamera", when attempting to copy the image-effects from the MainCamera to the VRCamera(s).  Currently, only the MainCamera should have it's effects copied.

### Testing status
Tested in various demo(content) scenes.

### Technical risk
Low.  This fix presented no exceptions, and is just a null check for an existing camera (tagged as "MainCamera"), performed before proceeding with image-effect copying.

### Comments to reviewers
If you'd like to induce the previous exception, for testing purposes, do the following:
- Create an empty scene
- Set the camera tag to "Untagged"
- Enable image-effect copying in the default EXR context
- Start EXR (exception will be immediately present in the console)