### PR TITLE
Improve intersection testing performance

### DIFF
--- a/Scripts/Utilities/IntersectionUtils.cs
+++ b/Scripts/Utilities/IntersectionUtils.cs
@@ -276,8 +276,12 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
             var mf = obj.GetComponent<MeshFilter>();
             if (mf)
             {
-                collisionTester.sharedMesh = mf.sharedMesh;
-                collisionTester.transform.localScale = Vector3.one;
+                if (collisionTester.sharedMesh != mf.sharedMesh)
+                {
+                    collisionTester.sharedMesh = mf.sharedMesh;
+                    collisionTester.transform.localScale = Vector3.one;
+                }
+
                 return;
             }
 


### PR DESCRIPTION
Every time .sharedMesh is set on a mesh collider PhysX has to bake out a mesh again, so this improves perf.