### PR TITLE
Adjust resolution for high-DPI screens

### DIFF
--- a/Scripts/Helpers/EditorWindowCapture.cs
+++ b/Scripts/Helpers/EditorWindowCapture.cs
@@ -101,9 +101,7 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
                 var rect = m_Position;
 
                 // Convert to GUI Rect (handles high-DPI screens)
-                float dpiScaling = Screen.dpi / 96f;
-                rect.width *= dpiScaling;
-                rect.height *= dpiScaling;
+                rect = EditorGUIUtility.PointsToPixels(rect);
 
                 // GrabPixels is relative to the GUIView and not the desktop, so we don't care about the offset
                 rect.x = 0f;

--- a/Scripts/Helpers/EditorWindowCapture.cs
+++ b/Scripts/Helpers/EditorWindowCapture.cs
@@ -100,6 +100,11 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
             {
                 var rect = m_Position;
 
+                // Convert to GUI Rect (handles high-DPI screens)
+                float dpiScaling = Screen.dpi / 96f;
+                rect.width *= dpiScaling;
+                rect.height *= dpiScaling;
+
                 // GrabPixels is relative to the GUIView and not the desktop, so we don't care about the offset
                 rect.x = 0f;
                 rect.y = 0f;


### PR DESCRIPTION
### Purpose of this PR

Minor fix for the profiler workspace

### Testing status

Manually tested

### Technical risk

Technical risk: low
Halo: low

### Comments to reviewers

Standard GUI is assuming a 96 dpi screen, so adjusting for DPIs that are higher than that (e.g. my laptop)