### PR TITLE
DPI fix

### DIFF
--- a/Scripts/Helpers/EditorWindowCapture.cs
+++ b/Scripts/Helpers/EditorWindowCapture.cs
@@ -28,6 +28,7 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
         EditorWindow m_Window;
         Object m_GuiView;
         MethodInfo m_GrabPixels;
+        Rect m_ScaledRect;
 
         /// <summary>
         /// RenderTexture that represents the captured Editor Window
@@ -80,6 +81,9 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
 
                 m_GrabPixels = guiViewType.GetMethod("GrabPixels", BindingFlags.Instance | BindingFlags.NonPublic);
 
+                // Convert to GUI Rect (handles high-DPI screens)
+                m_ScaledRect = EditorGUIUtility.PointsToPixels(m_Position);
+
                 capture = true;
             }
             else
@@ -98,10 +102,7 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
         {
             if (m_Window && capture)
             {
-                var rect = m_Position;
-
-                // Convert to GUI Rect (handles high-DPI screens)
-                rect = EditorGUIUtility.PointsToPixels(rect);
+                var rect = m_ScaledRect;
 
                 // GrabPixels is relative to the GUIView and not the desktop, so we don't care about the offset
                 rect.x = 0f;
@@ -120,7 +121,6 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
                     texture = new RenderTexture(width, height, 0);
                     texture.wrapMode = TextureWrapMode.Repeat;
                 }
-
 
                 k_GrabPixelsArgs[0] = texture;
                 k_GrabPixelsArgs[1] = rect;


### PR DESCRIPTION
### Purpose of this PR

Fix an issue where EditorWindowCapture workspaces would resize their content on hover if the window opens on a monitor with DPI scaling that does not match the main monitor

### Testing status

Tested on my work machine which has one monitor at 100% and the main at 150%. The content does not appear correctly if you move the window, but I was unable to find a workaround for that.

### Technical risk

Low--minor change that affects only EditorWindowCapture workspaces

### Comments to reviewers

This was tricky. It appears that anytime the window gets an event, it changes the global DPI scale factor, which causes `EditorGUIUtility.PointsToPixels` to return a different result. I couldn't find a way to get the specific window's DPI, and didn't want to go too deep down this rabbit hole. This solution works as long as you don't move the 2D window, which is unlikely to happen. These Capture Windows also don't gracefully handle window resizing, which would be an improvement worth considering, at which point we could revisit handling DPI dynamically.
