### PR TITLE
Spatial menu fixes

### DIFF
--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
@@ -508,20 +508,34 @@ namespace UnityEditor.Experimental.EditorVR.Menus
             {
                 // Spatial/cyclical/trackpad/thumbstick selection will set this reference
                 m_CurrentlyHighlightedMenuElement.selected(node);
+                for (int i = 0; i < m_CurrentlyDisplayedMenuElements.Count; ++i)
+                {
+                    if (m_CurrentlyDisplayedMenuElements[i] != null)
+                        m_CurrentlyDisplayedMenuElements[i].highlighted = false;
+                }
             }
             else
             {
                 // Search for an element that is being hovered,
                 // if no currentlyHighlightedMenuElement was assigned via a spatial/cyclical input means
+                var highlightedButtonFound = false;
                 for (int i = 0; i < m_CurrentlyDisplayedMenuElements.Count; ++i)
                 {
                     if (m_CurrentlyDisplayedMenuElements[i] != null)
                     {
-                        var highlighted = m_CurrentlyDisplayedMenuElements[i].highlighted;
-                        if (highlighted)
+                        if (!highlightedButtonFound)
                         {
-                            m_CurrentlyDisplayedMenuElements[i].selected(node);
-                            return;
+                            var highlighted = m_CurrentlyDisplayedMenuElements[i].highlighted;
+                            if (highlighted)
+                            {
+                                highlightedButtonFound = true;
+                                m_CurrentlyDisplayedMenuElements[i].selected(node);
+                                m_CurrentlyDisplayedMenuElements[i].highlighted = false;
+                            }
+                        }
+                        else
+                        {
+                            m_CurrentlyDisplayedMenuElements[i].highlighted = false;
                         }
                     }
                 }

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
@@ -388,6 +388,13 @@ namespace UnityEditor.Experimental.EditorVR.Menus
             m_HomeSectionDescription.gameObject.SetActive(true);
 
             m_CurrentlyDisplayedMenuElements.Clear();
+            var deleteOldChildren = m_SubMenuContainer.GetComponentsInChildren<Transform>().Where( x => x != m_SubMenuContainer);
+            foreach (var child in deleteOldChildren)
+            {
+                if (child != null && child.gameObject != null)
+                    ObjectUtils.Destroy(child.gameObject);
+            }
+
             var homeMenuElementParent = (RectTransform)m_HomeMenuLayoutGroup.transform;
             foreach (var data in spatialMenuData)
             {

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
@@ -496,10 +496,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
                     {
                         rayHoveringButton = m_CurrentlyDisplayedMenuElements[i].hoveringNode != Node.None;
                         if (rayHoveringButton)
-                        {
-                            rayHoveringButton = true;
                             break;
-                        }
                     }
                 }
 

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
@@ -258,9 +258,14 @@ namespace UnityEditor.Experimental.EditorVR.Menus
             }
         }
 
+        void Awake()
+        {
+            m_Visible = true;
+            visible = false;
+        }
+
         void Start()
         {
-            visible = false;
             m_ReturnToPreviousBackgroundMaterial = MaterialUtils.GetMaterialClone(m_ReturnToPreviousBackgroundRenderer);
             m_ReturnToPreviousBackgroundRenderer.material = m_ReturnToPreviousBackgroundMaterial;
             m_ReturnToPreviousBackgroundMaterial.SetFloat("_Blur", 0);

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
@@ -479,6 +479,10 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         public void SelectCurrentlyHighlightedElement(Node node)
         {
+            // In the case of a ray-based selection, don't process the selection of a currently highlighted element assigned via another input-mode
+            if (m_SpatialInterfaceInputMode == SpatialInterfaceInputMode.Ray)
+                return;
+
             if (m_CurrentlyHighlightedMenuElement != null)
             {
                 // Spatial/cyclical/trackpad/thumbstick selection will set this reference

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
@@ -488,7 +488,24 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         {
             // In the case of a ray-based selection, don't process the selection of a currently highlighted element assigned via another input-mode
             if (m_SpatialInterfaceInputMode == SpatialInterfaceInputMode.Ray)
-                return;
+            {
+                var rayHoveringButton = false;
+                for (int i = 0; i < m_CurrentlyDisplayedMenuElements.Count; ++i)
+                {
+                    if (m_CurrentlyDisplayedMenuElements[i] != null)
+                    {
+                        rayHoveringButton = m_CurrentlyDisplayedMenuElements[i].hoveringNode != Node.None;
+                        if (rayHoveringButton)
+                        {
+                            rayHoveringButton = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (rayHoveringButton)
+                    return;
+            }
 
             if (m_CurrentlyHighlightedMenuElement != null)
             {

--- a/Menus/SpatialUI/SpatialMenu/SpatialMenu.cs
+++ b/Menus/SpatialUI/SpatialMenu/SpatialMenu.cs
@@ -144,6 +144,7 @@ namespace UnityEditor.Experimental.EditorVR
                 if (s_SpatialMenuState == value)
                     return;
 
+                RefreshProviderData();
                 s_SpatialMenuState = value;
                 s_SpatialMenuUI.spatialMenuState = s_SpatialMenuState;
                 switch (s_SpatialMenuState)

--- a/Scripts/Input/OVRTouchInputToEvents.cs
+++ b/Scripts/Input/OVRTouchInputToEvents.cs
@@ -15,7 +15,7 @@ namespace UnityEditor.Experimental.EditorVR.Input
 #if ENABLE_OVR_INPUT
         const uint k_ControllerCount = 2;
         const int k_AxisCount = (int)VRInputDevice.VRControl.Analog9 + 1;
-        const float k_DeadZone = 0.001f;
+        const float k_DeadZone = 0.05f;
 
         float[,] m_LastAxisValues = new float[k_ControllerCount, k_AxisCount];
         Vector3[] m_LastPositionValues = new Vector3[k_ControllerCount];


### PR DESCRIPTION
### Purpose of this PR

Fix the following SpatialMenu related bugs:

*Fix exceptions present in the SpatialMenuUI when first activating the SpatialMenu and attempting to scroll if the menu is not already visible

*Fix SpatialMenu not displaying when first activated in a session

*Prevent the selection of more than one menu element in the SpatialMenu when in ray-input mode

*Prevent the selection of menu elements not currently being displayed when returning to the top-level of the menu.

*Fix bug relating to the thumbstick/trackpad selection of SpatialMenu elements not allowing for selection while in ray-based input mode

*Fix rare bug in which the SpatialMenu is either empty, or only displays the "actions" category when first displayed after quickly launching the menu on session start.

### Testing status

I've tested these fixes thoroughly. and saw no new issues relating to the SpatialMenu arise during testing.  In testing these fixes, I've tested for actions, workspaces, and tool buttons still functioning as expected in the SpatialMenu.

### Technical risk

Medium.  There are some notable, but necessary changes that have been made to check for a valid button the ray might be hovering, before falling back to a button that has been selected via the thumbstick/trackpad.  Manual resetting of the SpatialMenu highlight states was also added, as they weren't being reset previously, which was causing bugs.

### Comments to reviewers

None
