### PR TITLE
Hide the reset-size button on workspaces that prevent resizing

### DIFF
--- a/Workspaces/Base/WorkspaceUI.cs
+++ b/Workspaces/Base/WorkspaceUI.cs
@@ -346,6 +346,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
                 {
                     handle.gameObject.SetActive(!value);
                 }
+
+                m_ResizeButton.gameObject.SetActive(!value);
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR

The Workspace reset-size buttons are now hidden on the console & profiler workspaces (which cannot be resized), and are shown (as expected) on the other workspaces.  For better context, EditorWindowWorkspaces set preventResize to true, which should have hidden these previously.

### Testing status

Tested on all default EXR workspaces.  No issues were found.

### Technical risk

Low.  This is a non-invasive one-liner change that shouldn't affect any UI functionality in workspaces.

### Comments to reviewers

None