### PR TITLE
Fix an issue where custom tool menus never hide

### DIFF
--- a/Scripts/Core/EditorVR.Menus.cs
+++ b/Scripts/Core/EditorVR.Menus.cs
@@ -224,14 +224,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
                 foreach (var deviceData in k_ActiveDeviceData)
                 {
-                    foreach (var kvp in deviceData.menuHideData)
-                    {
-                        kvp.Value.hideFlags &= ~MenuHideFlags.Temporary;
-                    }
-                }
-
-                foreach (var deviceData in k_ActiveDeviceData)
-                {
                     IAlternateMenu alternateMenu = null;
                     var menuHideData = deviceData.menuHideData;
                     // Always display the highest-priority alternate menu, and hide all others.
@@ -351,6 +343,14 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
                     UpdateAlternateMenuForDevice(deviceData);
                     Rays.UpdateRayForDevice(deviceData, deviceData.rayOrigin);
+                }
+
+                foreach (var deviceData in k_ActiveDeviceData)
+                {
+                    foreach (var kvp in deviceData.menuHideData)
+                    {
+                        kvp.Value.hideFlags &= ~MenuHideFlags.Temporary;
+                    }
                 }
 
                 evr.GetModule<DeviceInputModule>().UpdatePlayerHandleMaps();

--- a/Scripts/Core/EditorVR.Rays.cs
+++ b/Scripts/Core/EditorVR.Rays.cs
@@ -110,7 +110,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
                     if (mainMenu.menuHideFlags == 0 || customMenu != null && customMenu.menuHideFlags == 0)
                         AddVisibilitySettings(rayOrigin, mainMenu, false, false);
                     else
-                        RemoveVisibilitySettings(rayOrigin, mainMenu);
+                        AddVisibilitySettings(rayOrigin, mainMenu, true, true, 1);
                 }
             }
 


### PR DESCRIPTION
### Purpose of this PR

This was broken by an earlier fix (fda33e21) to show the ray when the menu is hidden by workspaces--moving the for loop which clears temporary visibility to the top of UpdateMenuVisibilities caused all earlier visibility changes (i.e. from DeviceInputModule) to be overridden.

### Testing status

Tested by hovering over workspaces and UI with the Main Menu open on its own, with a custom tool menu (i.e. Annotation or CreatePrimitive) and with the Main Menu open "on top of" a custom tool menu

### Technical risk

Medium -- this changes how menu hiding works, which may introduce bugs relating to menu hiding.

### Comments to reviewers

The reason I switched from add/remove in UpdateRayForDevice to add/add is that I need to override the tool's setting to hide the ray--the tool is not aware that the menus are hiding, so we just need to leave its visibility setting in the list, and override it with a priority of 1.
