### PR TITLE
Spatial menu reposition delay change (extend GazeDivergenceModule)

### DIFF
--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
@@ -26,6 +26,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const string k_ExternalRayBasedInputModeName = "Ray Input Mode";
         const string k_TriggerRotationInputModeName = "Thumb Rotation Input Mode";
 
+        [Tooltip("Scales the amount of delay before the menu will reposition itself (higher is faster)")]
         [SerializeField]
         float m_AdaptiveRepositionRate = 1f;
 

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
@@ -15,7 +15,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
     /// The SpatialMenu's UI/View-controller
     /// Drives the SpatialMenu visuals elements
     /// </summary>
-    public sealed class SpatialMenuUI : SpatialUIView, IAdaptPosition, IConnectInterfaces, IUsesRaycastResults
+    public sealed class SpatialMenuUI : SpatialUIView, IAdaptPosition, IDetectGazeDivergence, IConnectInterfaces, IUsesRaycastResults
     {
         const float k_AllowedGazeDivergence = 45f;
         const float k_AllowedMaxHMDDistanceDivergence = 0.95f; // Distance at which the menu will move towards
@@ -25,6 +25,9 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const bool k_AlwaysRepositionIfOutOfFocus = true;
         const string k_ExternalRayBasedInputModeName = "Ray Input Mode";
         const string k_TriggerRotationInputModeName = "Thumb Rotation Input Mode";
+
+        [SerializeField]
+        float m_AdaptiveRepositionRate = 1f;
 
         [Header("Common UI")]
         [SerializeField]
@@ -299,6 +302,8 @@ namespace UnityEditor.Experimental.EditorVR.Menus
             // Manually set the backer bool to true, in order to perform a manual hiding of the menu in this case
             m_Visible = true;
             visible = false;
+
+            this.SetDivergenceRecoverySpeed(m_AdaptiveRepositionRate);
         }
 
         void Reset()

--- a/Menus/SpatialUI/SpatialMenu/SpatialMenu.prefab
+++ b/Menus/SpatialUI/SpatialMenu/SpatialMenu.prefab
@@ -2903,6 +2903,7 @@ MonoBehaviour:
     type: 2}
   m_SustainedHoverUIElementPulse: {fileID: 11400000, guid: ee3076deadaac0745b2d123bff3ecbff,
     type: 2}
+  m_AdaptiveRepositionRate: 0.5
   m_MainCanvasGroup: {fileID: 225156185928477662}
   m_Background: {fileID: 224190174565545938}
   m_InputModeText: {fileID: 114005941796262990}

--- a/Scripts/Core/InterfaceConnectors/GazeDivergenceModuleConnector.cs
+++ b/Scripts/Core/InterfaceConnectors/GazeDivergenceModuleConnector.cs
@@ -10,6 +10,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
             public void LateBindInterfaceMethods(GazeDivergenceModule provider)
             {
                 IDetectGazeDivergenceMethods.isAboveDivergenceThreshold = provider.IsAboveDivergenceThreshold;
+                IDetectGazeDivergenceMethods.setDivergenceRecoverySpeed = provider.SetGazeDivergenceRecoverySpeed;
             }
         }
     }

--- a/Scripts/Interfaces/FunctionalityInjection/IDetectGazeDivergence.cs
+++ b/Scripts/Interfaces/FunctionalityInjection/IDetectGazeDivergence.cs
@@ -14,11 +14,20 @@ namespace UnityEditor.Experimental.EditorVR
     {
         internal delegate bool IsAboveDivergenceThresholdDelegate(IDetectGazeDivergence obj, Transform transformToTest, float divergenceThreshold, bool disregardTemporalStability = true);
 
+        internal delegate float SetDivergenceRecoverySpeedDelegate(IDetectGazeDivergence obj, float rateAtWhichGazeVelocityReturnsToStableThreshold);
+
         internal static Func<Transform, float, bool, bool> isAboveDivergenceThreshold { private get; set; }
+
+        internal static Action<float> setDivergenceRecoverySpeed { private get; set; }
 
         public static bool IsAboveDivergenceThreshold(this IDetectGazeDivergence obj, Transform transformToTest, float divergenceThreshold, bool disregardTemporalStability = true)
         {
             return isAboveDivergenceThreshold(transformToTest, divergenceThreshold, disregardTemporalStability);
+        }
+
+        public static void SetDivergenceRecoverySpeed(this IDetectGazeDivergence obj, float rateAtWhichGazeVelocityReturnsToStableThreshold)
+        {
+            setDivergenceRecoverySpeed(rateAtWhichGazeVelocityReturnsToStableThreshold);
         }
     }
 }

--- a/Scripts/Modules/GazeDivergenceModule/GazeDivergenceModule.cs
+++ b/Scripts/Modules/GazeDivergenceModule/GazeDivergenceModule.cs
@@ -14,11 +14,12 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         Transform m_GazeSourceTransform;
         Quaternion m_PreviousGazeRotation;
         float m_GazeVelocity;
+        float m_DivergenceSpeedScalar = 1f;
 
         /// <summary>
         /// Is the gaze currently focused on a single location, and not scanning the surrounding FOV above a certain velocity
         /// </summary>
-        public bool gazeStable { get { return m_GazeVelocity < k_StableGazeThreshold; } }
+        bool gazeStable { get { return m_GazeVelocity < k_StableGazeThreshold; } }
 
         void Awake()
         {
@@ -32,8 +33,25 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             var gazeRotationDifference = Quaternion.Angle(currentGazeSourceRotation, m_PreviousGazeRotation);
             gazeRotationDifference *= gazeRotationDifference; // Square the difference for intended response curve/shape
             m_GazeVelocity = m_GazeVelocity + gazeRotationDifference * Time.unscaledDeltaTime;
-            m_GazeVelocity = Mathf.Clamp01(m_GazeVelocity - Time.unscaledDeltaTime);
+            m_GazeVelocity = Mathf.Clamp01(m_GazeVelocity - Time.unscaledDeltaTime * m_DivergenceSpeedScalar);
             m_PreviousGazeRotation = currentGazeSourceRotation; // Cache the previous camera rotation
+        }
+
+        /// <summary>
+        /// Set the value that scales the rate at which the gaze velocity will return to the stable threshold (below the gaze divergence threshold)
+        /// A value of 1 will allow the gaze velocity to return to the stable threshold value at its' normal rate
+        /// A value less than 1 will increase the rate at which the gaze velocity returns to the stable gaze threshold value (slower)
+        /// A value greater than 1 will increase the rate at which the gaze velocity returns to the stable gaze threshold value (faster)
+        /// </summary>
+        /// <param name="rateAtWhichGazeVelocityReturnsToStableThreshold">The rate at which gaze velocity returns to stable threshold</param>
+        public void SetGazeDivergenceRecoverySpeed (float rateAtWhichGazeVelocityReturnsToStableThreshold)
+        {
+            const float minSpeed = 0.01f;
+            rateAtWhichGazeVelocityReturnsToStableThreshold = Mathf.Abs(rateAtWhichGazeVelocityReturnsToStableThreshold); // don't allow negative values
+            if (Mathf.Approximately(rateAtWhichGazeVelocityReturnsToStableThreshold, 0f))
+                rateAtWhichGazeVelocityReturnsToStableThreshold = minSpeed; // prevent the gaze velocity from never being able to return to the stable threshold
+
+            m_DivergenceSpeedScalar = rateAtWhichGazeVelocityReturnsToStableThreshold;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose of this PR

*When the user diverts their gaze from the already open SpatialMenu, extend the SpatialMenu's adaptive re-positioning wait duration to be longer than it previously was (around 2X longer now).

*Add functionality allowing for the rate at which the gaze velocity will return to the stable threshold value in the GazeDivergenceModule.

### Testing status

Tested many times over while refining the now slower re-position value set for the SpatialMenu.

### Technical risk

Low.  These changes don't affect any existing implementations outside of the GazeDivergenceModule.  Though at some point, the gaze divergence module should be extended to support per-implementer rates of gaze velocity speed scaling.

### Comments to reviewers

You can tune the value that scales the adaptive re-position speed on the SpatialMenu prefab's SpatialMenuUI component
