### PR TITLE
Menu/Ray hiding fix

### DIFF
--- a/Scripts/Core/EditorVR.Rays.cs
+++ b/Scripts/Core/EditorVR.Rays.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor.Experimental.EditorVR.Helpers;
 using UnityEditor.Experimental.EditorVR.Manipulators;
+using UnityEditor.Experimental.EditorVR.Menus;
 using UnityEditor.Experimental.EditorVR.Modules;
 using UnityEditor.Experimental.EditorVR.Proxies;
 using UnityEditor.Experimental.EditorVR.Utilities;
@@ -107,9 +108,11 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
                 if (mainMenu != null)
                 {
+                    // Hide the cone and ray if the main menu or custom menu are open
                     if (mainMenu.menuHideFlags == 0 || customMenu != null && customMenu.menuHideFlags == 0)
                         AddVisibilitySettings(rayOrigin, mainMenu, false, false);
-                    else
+                    // Show the ray if the menu is not hidden but the custom menu is overriding it, and is also hidden
+                    else if ((mainMenu.menuHideFlags & MenuHideFlags.Hidden) == 0 || customMenu != null && customMenu.menuHideFlags != 0)
                         AddVisibilitySettings(rayOrigin, mainMenu, true, true, 1);
                 }
             }

--- a/Scripts/Core/EditorVR.Rays.cs
+++ b/Scripts/Core/EditorVR.Rays.cs
@@ -114,6 +114,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
                     // Show the ray if the menu is not hidden but the custom menu is overriding it, and is also hidden
                     else if ((mainMenu.menuHideFlags & MenuHideFlags.Hidden) == 0 || customMenu != null && customMenu.menuHideFlags != 0)
                         AddVisibilitySettings(rayOrigin, mainMenu, true, true, 1);
+                    else
+                        RemoveVisibilitySettings(rayOrigin, mainMenu);
                 }
             }
 


### PR DESCRIPTION
### Purpose of this PR

Fix a bug introduced by #517 where the priority-1 ray visibility settings would override tools trying to hide the ray

### Testing status

Tested by opening Annotation and/or CreatePrimitive tool. Previously the ray would show on the primary tool hand. Now it does not. Also tested the ray returning after hiding the menu when in proximity to a workspace, which is what the priority-1 change was fixing.

### Technical risk

Low - Only affects ray visibility in a particular edge case

### Comments to reviewers

Good 'ol bug whack-a-mole
