### PR TITLE
Fix error spam from OnAutoOpenStateChanged

### DIFF
--- a/Scripts/Core/Contexts/EditingContextManager.cs
+++ b/Scripts/Core/Contexts/EditingContextManager.cs
@@ -96,7 +96,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
             VRView.viewEnabled += OnVRViewEnabled;
             VRView.viewDisabled += OnVRViewDisabled;
             EditorApplication.update += ReopenOnExitPlaymode;
-            OnAutoOpenStateChanged();
+            EditorApplication.delayCall += OnAutoOpenStateChanged;
         }
 #endif
 


### PR DESCRIPTION
### Purpose of this PR

We missed a bug that was introduced in #513. If you recompiled scripts with the EXR Runtime scene open (or any scene with an EditingContextManager in it), you would see UnityExceptions spammed into the console

### Testing status

Tested recompiling with EXR Runtime scene open on dev--error spam. Same procedure on this branch--no error spam.

### Technical risk

Low -- One-line fix

### Comments to reviewers

It looks like the reason this was only showing up on scene load is that the call to AwakeStart would JIT the EditingContextManager class before normal InitializeOnLoad, thus trying to access the EditorPref too early. The solve is to just do first-time setup in a delaycall.
