### PR TITLE
Fix ray-based priority selection of SpatialMenu elements

### DIFF
--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuSectionTitleElement.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuSectionTitleElement.cs
@@ -75,7 +75,15 @@ namespace UnityEditor.Experimental.EditorVR
 
         void Select()
         {
-            var selectionNode = hoveringNode != Node.None ? hoveringNode : spatialMenuActiveControllerNode;
+            var beingHoveredByRay = hoveringNode != Node.None;
+            var selectionNode = beingHoveredByRay ? hoveringNode : spatialMenuActiveControllerNode;
+
+            // Force this element to be selected again when switching menu levels
+            // due to the ray taking precedence over a non-ray-based highlighted item
+            // The button will be cleaned up regardless on menu level change or close
+            if (beingHoveredByRay)
+                highlighted = true;
+
             if (selected != null)
                 selected(selectionNode);
         }

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
@@ -419,9 +419,27 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         {
             m_BackButton.allowInteraction = true;
             ForceClearHomeMenuElements();
+
+            // Find any element hovered by a ray, for later comparison and selection override
+            // of menu elements highlighted via other input modes
+            SpatialMenu.SpatialMenuData rayHoveredElementMenuData = null;
+            if (spatialInterfaceInputMode == SpatialInterfaceInputMode.Ray)
+            {
+                foreach (var menuElement in m_CurrentlyDisplayedMenuElements)
+                {
+                    if (menuElement.hoveringNode != Node.None && menuElement.parentMenuData != null)
+                    {
+                        rayHoveredElementMenuData = menuElement.parentMenuData;
+                        break;
+                    }
+                }
+            }
+
             foreach (var menuData in spatialMenuData)
             {
-                if (menuData.highlighted)
+                // Ray-based elements that are highlighted should take precedence over elements highlighted by other means
+                // (neutral, BCI, etc) when changing menu levels
+                if (menuData.highlighted && (rayHoveredElementMenuData == null || rayHoveredElementMenuData == menuData))
                 {
                     m_CurrentlyDisplayedMenuElements.Clear();
                     var deleteOldChildren = m_SubMenuContainer.GetComponentsInChildren<Transform>().Where( x => x != m_SubMenuContainer);


### PR DESCRIPTION
### Purpose of this PR

Fix ray-based priority selection of SpatialMenu elements.  Previously other SpatialMenu input modes would override the selection of ray-based hovered buttons.

### Testing status

Tested in various SpatialMenu scenarios that would trigger the issue, and many "standard" SpatialMenu combinations of actions.  I saw none of the previous issues, and no new issues present themselves.

### Technical risk

Low -- These changes were kept isolated to the DisplayHighlightedSubMenuContents function in the SpatialMenuUI.  In addition, there was a minor change made as to how highlighting is handled when selecting elements in the SpatialMenuSectionTitleElement controller.  That change is automatically cleaned up when changing menu levels, will will occur during the selection of a TitleMenuElement; so shouldn't affect anything else.

### Comments to reviewers

To repro the issue, (use a different branch), the use the thumbstick/trackpad to highlight a button in the Spatial Menu AFTER you have highlighted a button via a ray.  When you use the trigger to select the button currently highlighted by the ray, you will select the button that was highlighted afterward via the thumbstick.  This is the issue that has been remedied.