### PR TITLE
Fix bug blocking selection of SpatialMenu sub-menu elements with opposite hand

### DIFF
--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
@@ -518,10 +518,11 @@ namespace UnityEditor.Experimental.EditorVR.Menus
             }
         }
 
-        public void SelectCurrentlyHighlightedElement(Node node)
+        public void SelectCurrentlyHighlightedElement(Node node, bool isNodeThatActivatedMenu)
         {
             // In the case of a ray-based selection, don't process the selection of a currently highlighted element assigned via another input-mode
-            if (m_SpatialInterfaceInputMode == SpatialInterfaceInputMode.Ray)
+            // Nodes not activating this menu are allowed to skip this check, as they can't have highlighted an element via neutral/trackpad/touchpad input
+            if (m_SpatialInterfaceInputMode == SpatialInterfaceInputMode.Ray && isNodeThatActivatedMenu)
             {
                 var rayHoveringButton = false;
                 for (int i = 0; i < m_CurrentlyDisplayedMenuElements.Count; ++i)

--- a/Menus/SpatialUI/SpatialMenu/SpatialMenu.cs
+++ b/Menus/SpatialUI/SpatialMenu/SpatialMenu.cs
@@ -330,7 +330,7 @@ namespace UnityEditor.Experimental.EditorVR
                 // Though they may need their input actions to drive certain SpatialMenu functionality
                 var cancelJustPressed = CancelWasJustPressedTest(consumeControl);
                 if (!cancelJustPressed) // Only process selection testing if cancel was not just pressed
-                    SelectJustPressedTest(consumeControl);
+                    SelectJustPressedTest(consumeControl, false);
 
                 return;
             }
@@ -413,7 +413,7 @@ namespace UnityEditor.Experimental.EditorVR
                 {
                     if (m_CurrentSpatialActionMapInput.select.wasJustPressed)
                     {
-                        s_SpatialMenuUI.SelectCurrentlyHighlightedElement(node);
+                        s_SpatialMenuUI.SelectCurrentlyHighlightedElement(node, true);
                     }
                     else if (m_CircularTriggerSelectionCyclingCoroutine == null)
                     {
@@ -479,14 +479,14 @@ namespace UnityEditor.Experimental.EditorVR
             return cancelJustPressed;
         }
 
-        void SelectJustPressedTest(ConsumeControlDelegate consumeControl)
+        void SelectJustPressedTest(ConsumeControlDelegate consumeControl, bool isNodeThatActivatedMenu = true)
         {
             if (m_CurrentSpatialActionMapInput.select.wasJustPressed)
             {
                 if (s_SpatialMenuState == SpatialMenuState.NavigatingTopLevel)
                     s_SpatialMenuUI.SectionTitleButtonSelected(node);
                 else if (s_SpatialMenuState == SpatialMenuState.NavigatingSubMenuContent)
-                    s_SpatialMenuUI.SelectCurrentlyHighlightedElement(node);
+                    s_SpatialMenuUI.SelectCurrentlyHighlightedElement(node, isNodeThatActivatedMenu);
 
                 ConsumeControls(m_CurrentSpatialActionMapInput, consumeControl);
             }


### PR DESCRIPTION
### Purpose of this PR

Fix bug blocking selection of SpatialMenu sub-menu elements with a node(proxy/controller) that wasn't the node that activated the menu

### Testing status

Tested thoroughly.  No new unidentified SpatialMenu bugs arose from these changes.

### Technical risk

Low.  The changes were relegated to a new parameter in the SelectCurrentlyHighlightedElement function, in SpatialMenuUI, informing the logic as to the calling node being the node that is currently owning SpatialInput (allowing for the bypass of specific ray-based processing that should only occur for the controlling node).

### Comments to reviewers

Easiest repro, is trigger the Spatial Menu with one hand, then attempt to open a workspace, or add a tool, with the other hand.  It wasn't working previously, now it is.