### PR TITLE
Fix compile errors in 2017 from BuildCallbacks

### DIFF
--- a/Editor/BuildCallbacks.cs
+++ b/Editor/BuildCallbacks.cs
@@ -8,7 +8,6 @@ using UnityEngine;
 
 #if UNITY_2018_1_OR_NEWER
 using UnityEditor.Build.Reporting;
-#else
 #endif
 
 namespace UnityEditor.Experimental.EditorVR

--- a/Editor/BuildCallbacks.cs
+++ b/Editor/BuildCallbacks.cs
@@ -2,14 +2,22 @@
 using System.Collections.Generic;
 using System.IO;
 using UnityEditor.Build;
-using UnityEditor.Build.Reporting;
 using UnityEditor.Compilation;
 using UnityEditorInternal;
 using UnityEngine;
 
+#if UNITY_2018_1_OR_NEWER
+using UnityEditor.Build.Reporting;
+#else
+#endif
+
 namespace UnityEditor.Experimental.EditorVR
 {
+#if UNITY_2018_1_OR_NEWER
     class BuildCallbacks : IPreprocessBuildWithReport, IPostprocessBuildWithReport
+#else
+    class BuildCallbacks : IPreprocessBuild, IPostprocessBuild
+#endif
     {
         [Serializable]
         class AssemblyDefinition
@@ -37,7 +45,7 @@ namespace UnityEditor.Experimental.EditorVR
             public string[] ExcludePlatforms { get { return excludePlatforms; } set { excludePlatforms = value; } }
         }
 
-        static readonly string[] k_AssemblyNames = { "EXR", "EXR-Dependencies", "input-prototype", "VRLR"  };
+        static readonly string[] k_AssemblyNames = { "EXR", "EXR-Dependencies", "input-prototype", "VRLR" };
         static readonly string[] k_IncludePlatformsOverride = { "Editor" };
         static readonly string[] k_ExcludePlatformsOverride = { };
         static readonly Dictionary<string, string[]> k_IncludePlatforms = new Dictionary<string, string[]>();
@@ -71,7 +79,11 @@ namespace UnityEditor.Experimental.EditorVR
             }
         }
 
+#if UNITY_2018_1_OR_NEWER
         public void OnPreprocessBuild(BuildReport report)
+#else
+        public void OnPreprocessBuild(BuildTarget target, string path)
+#endif
         {
             if (Core.EditorVR.includeInBuilds)
                 return;
@@ -92,7 +104,11 @@ namespace UnityEditor.Experimental.EditorVR
             AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
         }
 
+#if UNITY_2018_1_OR_NEWER
         public void OnPostprocessBuild(BuildReport report)
+#else
+        public void OnPostprocessBuild(BuildTarget target, string path)
+#endif
         {
             OnPostprocessBuild();
         }


### PR DESCRIPTION
### Purpose of this PR

Does what it says

### Testing status

Tested in 2017.3.0f3 and 2018.3.6f1

### Technical risk

Low -- Just an API change

### Comments to reviewers

This code relies on Assembly Definitions, which were introduced in 2017.3. It is the only thing in the codebase which currently increases the minimum supported version from 2017.2.0p2 to 2017.3.0f3. The Packman version of Text Mesh Pro also relies on Assembly Definitions, which also breaks support for versions before 2017.3.0f3.
