### PR TITLE
Fix warnings

### DIFF
--- a/Actions/BaseAction.cs
+++ b/Actions/BaseAction.cs
@@ -7,13 +7,15 @@ namespace UnityEditor.Experimental.EditorVR.Actions
     /// </summary>
     abstract class BaseAction : MonoBehaviour, IAction
     {
+#pragma warning disable 649
+        [SerializeField]
+        Sprite m_Icon;
+#pragma warning restore 649
+
         public Sprite icon
         {
             get { return m_Icon; }
         }
-
-        [SerializeField]
-        Sprite m_Icon;
 
         public abstract void ExecuteAction();
     }

--- a/Editor/LockableHierarchyGUI.cs
+++ b/Editor/LockableHierarchyGUI.cs
@@ -4,11 +4,13 @@ using UnityEngine;
 [InitializeOnLoad]
 class LockableHierarchyGUI : ScriptableSingleton<LockableHierarchyGUI>
 {
+#pragma warning disable 649
     [SerializeField]
     Texture2D m_LockIcon;
 
     [SerializeField]
     Texture2D m_UnlockIcon;
+#pragma warning restore 649
 
     static LockableHierarchyGUI()
     {

--- a/Manipulators/BaseManipulator.cs
+++ b/Manipulators/BaseManipulator.cs
@@ -8,10 +8,6 @@ namespace UnityEditor.Experimental.EditorVR.Manipulators
 {
     class BaseManipulator : MonoBehaviour, IManipulator
     {
-        protected const float k_BaseManipulatorSize = 0.3f;
-        const float k_MinHandleTipDirectionDelta = 0.01f;
-        const float k_LazyFollow = 40f;
-
         class HandleTip
         {
             public Renderer renderer;
@@ -20,6 +16,12 @@ namespace UnityEditor.Experimental.EditorVR.Manipulators
             public Vector3? positionOffset;
         }
 
+        const float k_MinHandleTipDirectionDelta = 0.01f;
+        const float k_LazyFollow = 40f;
+
+        protected const float k_BaseManipulatorSize = 0.3f;
+
+#pragma warning disable 649
         [SerializeField]
         Renderer m_HandleTip;
 
@@ -40,6 +42,7 @@ namespace UnityEditor.Experimental.EditorVR.Manipulators
 
         [SerializeField]
         float m_HandleHoverAlpha = 0.8f;
+#pragma warning restore 649
 
         readonly Dictionary<Type, float> m_ScaleBumps = new Dictionary<Type, float>();
         readonly Dictionary<Transform, HandleTip> m_HandleTips = new Dictionary<Transform, HandleTip>();

--- a/Manipulators/ScaleManipulator.cs
+++ b/Manipulators/ScaleManipulator.cs
@@ -5,8 +5,10 @@ namespace UnityEditor.Experimental.EditorVR.Manipulators
 {
     sealed class ScaleManipulator : BaseManipulator
     {
+#pragma warning disable 649
         [SerializeField]
         BaseHandle m_UniformHandle;
+#pragma warning restore 649
 
         protected override void OnHandleDragging(BaseHandle handle, HandleEventData eventData)
         {

--- a/Manipulators/StandardManipulator.cs
+++ b/Manipulators/StandardManipulator.cs
@@ -6,6 +6,7 @@ namespace UnityEditor.Experimental.EditorVR.Manipulators
 {
     sealed class StandardManipulator : BaseManipulator
     {
+#pragma warning disable 649
         [SerializeField]
         Transform m_PlaneHandlesParent;
 
@@ -17,6 +18,7 @@ namespace UnityEditor.Experimental.EditorVR.Manipulators
 
         [SerializeField]
         float m_SphereHandleHideScale = 0.1f;
+#pragma warning restore 649
 
         void Update()
         {

--- a/Menus/MainMenu/MainMenu.cs
+++ b/Menus/MainMenu/MainMenu.cs
@@ -18,6 +18,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const string k_SettingsMenuSectionName = "Settings";
         const float k_MaxFlickDuration = 0.3f;
 
+#pragma warning disable 649
         [SerializeField]
         ActionMap m_ActionMap;
 
@@ -38,6 +39,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         HapticPulse m_ButtonHoverPulse;
+#pragma warning restore 649
 
         Transform m_AlternateMenuOrigin;
         Transform m_MenuOrigin;

--- a/Menus/MainMenu/Scripts/MainMenuButton.cs
+++ b/Menus/MainMenu/Scripts/MainMenuButton.cs
@@ -12,8 +12,10 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 {
     sealed class MainMenuButton : MainMenuSelectable, ITooltip, IRayEnterHandler, IRayExitHandler, IPointerClickHandler
     {
+#pragma warning disable 649
         [SerializeField]
         Button m_Button;
+#pragma warning restore 649
 
         CanvasGroup m_CanvasGroup;
 

--- a/Menus/MainMenu/Scripts/MainMenuFace.cs
+++ b/Menus/MainMenu/Scripts/MainMenuFace.cs
@@ -20,6 +20,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
     {
         static readonly Vector3 k_LocalOffset = Vector3.down * 0.15f;
 
+#pragma warning disable 649
         [SerializeField]
         MeshRenderer m_BorderOutline;
 
@@ -39,6 +40,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         ScrollRect m_ScrollRect;
+#pragma warning restore 649
 
         Material m_BorderOutlineMaterial;
         Vector3 m_BorderOutlineOriginalLocalScale;

--- a/Menus/MainMenu/Scripts/MainMenuToggle.cs
+++ b/Menus/MainMenu/Scripts/MainMenuToggle.cs
@@ -11,8 +11,10 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 {
     sealed class MainMenuToggle : MainMenuSelectable, IRayEnterHandler, IRayExitHandler, IPointerClickHandler
     {
+#pragma warning disable 649
         [SerializeField]
         Toggle m_Toggle;
+#pragma warning restore 649
 
         CanvasGroup m_CanvasGroup;
 

--- a/Menus/MainMenu/Scripts/MainMenuUI.cs
+++ b/Menus/MainMenu/Scripts/MainMenuUI.cs
@@ -42,6 +42,9 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const float k_RotationEpsilon = 1f;
         const int k_FaceCount = 4;
 
+        const string k_UncategorizedFaceName = "Uncategorized";
+        static readonly Color k_MenuFacesHiddenColor = new Color(1f, 1f, 1f, 0.5f);
+
 #pragma warning disable 649
         [SerializeField]
         MainMenuButton m_ButtonTemplatePrefab;
@@ -61,9 +64,6 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         [SerializeField]
         Transform m_AlternateMenu;
 #pragma warning restore 649
-
-        readonly string k_UncategorizedFaceName = "Uncategorized";
-        readonly Color k_MenuFacesHiddenColor = new Color(1f, 1f, 1f, 0.5f);
 
         int m_TargetFaceIndex;
 

--- a/Menus/MainMenu/Scripts/MainMenuUI.cs
+++ b/Menus/MainMenu/Scripts/MainMenuUI.cs
@@ -42,9 +42,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const float k_RotationEpsilon = 1f;
         const int k_FaceCount = 4;
 
-        readonly string k_UncategorizedFaceName = "Uncategorized";
-        readonly Color k_MenuFacesHiddenColor = new Color(1f, 1f, 1f, 0.5f);
-
+#pragma warning disable 649
         [SerializeField]
         MainMenuButton m_ButtonTemplatePrefab;
 
@@ -62,6 +60,10 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         Transform m_AlternateMenu;
+#pragma warning restore 649
+
+        readonly string k_UncategorizedFaceName = "Uncategorized";
+        readonly Color k_MenuFacesHiddenColor = new Color(1f, 1f, 1f, 0.5f);
 
         int m_TargetFaceIndex;
 

--- a/Menus/RadialMenu/RadialMenu.cs
+++ b/Menus/RadialMenu/RadialMenu.cs
@@ -14,6 +14,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const float k_ActivationThreshold = 0.5f; // Do not consume thumbstick or activate menu if the control vector's magnitude is below this threshold
         const string k_SpatialDescription = "Perform actions based on selected-object context";
 
+#pragma warning disable 649
         [SerializeField]
         ActionMap m_ActionMap;
 
@@ -28,6 +29,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         HapticPulse m_ButtonClickedPulse;
+#pragma warning restore 649
 
         RadialMenuUI m_RadialMenuUI;
         List<ActionMenuData> m_MenuActions;

--- a/Menus/RadialMenu/Scripts/RadialMenuSlot.cs
+++ b/Menus/RadialMenu/Scripts/RadialMenuSlot.cs
@@ -11,8 +11,6 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 {
     sealed class RadialMenuSlot : MonoBehaviour, ISetTooltipVisibility, ITooltip, ITooltipPlacement, IRayEnterHandler, IRayExitHandler
     {
-        static Color s_FrameOpaqueColor;
-        static GradientPair s_GradientPair;
         static readonly Vector3 k_HiddenLocalScale = new Vector3(1f, 0f, 1f);
         const float k_IconHighlightedLocalYOffset = 0.006f;
         const string k_MaterialAlphaProperty = "_Alpha";
@@ -22,6 +20,10 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const string k_MaterialColorProperty = "_Color";
         const string k_MaterialStencilRefProperty = "_StencilRef";
 
+        static Color s_FrameOpaqueColor;
+        static GradientPair s_GradientPair;
+
+#pragma warning disable 649
         [SerializeField]
         MeshRenderer m_InsetMeshRenderer;
 
@@ -54,6 +56,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         Transform m_TooltipSource;
+#pragma warning restore 649
 
         bool m_Pressed;
         bool m_Highlighted;
@@ -107,7 +110,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
                 // Proceed only if value is true after previously being false
                 if (m_Highlighted && value != m_Pressed && value && gameObject.activeSelf)
                 {
-                    m_Pressed = value;
+                    m_Pressed = true;
 
                     this.StopCoroutine(ref m_IconHighlightCoroutine);
 
@@ -169,7 +172,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         {
             set
             {
-                if (value && m_Visible == value) // Allow false to fall through and perform hiding regardless of visibility
+                if (value && m_Visible) // Allow false to fall through and perform hiding regardless of visibility
                     return;
 
                 m_Visible = value;
@@ -394,23 +397,20 @@ namespace UnityEditor.Experimental.EditorVR.Menus
             HighlightIcon();
 
             var opacity = Time.deltaTime;
-            var topColor = m_OriginalInsetGradientPair.a;
-            var bottomColor = m_OriginalInsetGradientPair.b;
             var initialFrameColor = m_FrameMaterial.color;
-            var currentFrameColor = initialFrameColor;
             while (opacity > 0)
             {
                 if (m_Highlighted)
                 {
                     opacity = Mathf.Clamp01(opacity + Time.deltaTime * 4); // stay highlighted
-                    currentFrameColor = Color.Lerp(initialFrameColor, s_FrameOpaqueColor, opacity);
+                    var currentFrameColor = Color.Lerp(initialFrameColor, s_FrameOpaqueColor, opacity);
                     m_FrameMaterial.SetColor(k_MaterialColorProperty, currentFrameColor);
                 }
                 else
                     opacity = Mathf.Clamp01(opacity - Time.deltaTime * 2);
 
-                topColor = Color.Lerp(m_OriginalInsetGradientPair.a, s_GradientPair.a, opacity * 2f);
-                bottomColor = Color.Lerp(m_OriginalInsetGradientPair.b, s_GradientPair.b, opacity);
+                var topColor = Color.Lerp(m_OriginalInsetGradientPair.a, s_GradientPair.a, opacity * 2f);
+                var bottomColor = Color.Lerp(m_OriginalInsetGradientPair.b, s_GradientPair.b, opacity);
 
                 m_InsetMaterial.SetColor(k_MaterialColorTopProperty, topColor);
                 m_InsetMaterial.SetColor(k_MaterialColorBottomProperty, bottomColor);

--- a/Menus/RadialMenu/Scripts/RadialMenuUI.cs
+++ b/Menus/RadialMenu/Scripts/RadialMenuUI.cs
@@ -12,6 +12,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
     {
         const int k_SlotCount = 16;
 
+#pragma warning disable 649
         [SerializeField]
         Sprite m_MissingActionIcon;
 
@@ -20,6 +21,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         Transform m_SlotContainer;
+#pragma warning restore 649
 
         List<RadialMenuSlot> m_RadialMenuSlots;
         Coroutine m_VisibilityCoroutine;

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuBackButton.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuBackButton.cs
@@ -8,10 +8,12 @@ using UnityEngine.UI;
 
 namespace UnityEditor.Experimental.EditorVR.Menus
 {
-    internal class SpatialMenuBackButton : MonoBehaviour, IControlHaptics, IRayEnterHandler, IRayExitHandler
+    class SpatialMenuBackButton : MonoBehaviour, IControlHaptics, IRayEnterHandler, IRayExitHandler
     {
+#pragma warning disable 649
         [SerializeField]
         Button m_Button;
+#pragma warning restore 649
 
         Image m_ButtonImage;
         Vector3 m_VisibleLocalScale;

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuSectionTitleElement.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuSectionTitleElement.cs
@@ -13,18 +13,11 @@ namespace UnityEditor.Experimental.EditorVR
         [Header("Haptic Pulses")]
         [SerializeField]
         HapticPulse m_HighlightPulse;
-
-        [SerializeField]
-        HapticPulse m_TooltipDisplayPulse;
 #pragma warning restore 649
 
-        Vector2 m_ExpandedTooltipDisplaySize;
         Coroutine m_VisibilityCoroutine;
-        Coroutine m_TooltipVisualsVisibilityCoroutine;
         Vector3 m_TextOriginalLocalPosition;
         bool m_Highlighted;
-        Vector3 m_OriginalBordersLocalScale;
-        float m_BordersOriginalAlpha;
         bool m_Visible;
 
         public override bool visible
@@ -110,7 +103,7 @@ namespace UnityEditor.Experimental.EditorVR
 
         void OnEnable()
         {
-            // Cacheing position here, as layout groups were altering the position when originally cacheing in Start()
+            // Caching position here, as layout groups were altering the position when originally caching in Start()
             m_TextOriginalLocalPosition = m_Text.transform.localPosition;
         }
 
@@ -148,8 +141,8 @@ namespace UnityEditor.Experimental.EditorVR
 
         IEnumerator AnimateHighlight(bool isHighlighted)
         {
+            const float targetAlpha = 1f;
             var currentAlpha = m_CanvasGroup.alpha;
-            var targetAlpha = 1f;
             var alphaTransitionAmount = 0f;
             var textTransform = m_Text.transform;
             var textCurrentLocalPosition = textTransform.localPosition;

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuSectionTitleElement.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuSectionTitleElement.cs
@@ -7,21 +7,23 @@ using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR
 {
-    sealed internal class SpatialMenuSectionTitleElement : SpatialMenuElement
+    sealed class SpatialMenuSectionTitleElement : SpatialMenuElement
     {
+#pragma warning disable 649
         [Header("Haptic Pulses")]
         [SerializeField]
         HapticPulse m_HighlightPulse;
 
         [SerializeField]
         HapticPulse m_TooltipDisplayPulse;
+#pragma warning restore 649
 
         Vector2 m_ExpandedTooltipDisplaySize;
         Coroutine m_VisibilityCoroutine;
         Coroutine m_TooltipVisualsVisibilityCoroutine;
         Vector3 m_TextOriginalLocalPosition;
         bool m_Highlighted;
-        Vector3 m_OriginalBordersLohocalScale;
+        Vector3 m_OriginalBordersLocalScale;
         float m_BordersOriginalAlpha;
         bool m_Visible;
 

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuSubMenuElement.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuSubMenuElement.cs
@@ -9,8 +9,9 @@ using UnityEngine.UI;
 
 namespace UnityEditor.Experimental.EditorVR
 {
-    sealed internal class SpatialMenuSubMenuElement : SpatialMenuElement
+    sealed class SpatialMenuSubMenuElement : SpatialMenuElement
     {
+#pragma warning disable 649
         [SerializeField]
         Image m_BackgroundImage;
 
@@ -43,6 +44,7 @@ namespace UnityEditor.Experimental.EditorVR
 
         [SerializeField]
         HapticPulse m_TooltipDisplayPulse;
+#pragma warning restore 649
 
         RectTransform m_RectTransform;
         Vector2 m_OriginalSize;

--- a/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
+++ b/Menus/SpatialUI/SpatialMenu/Scripts/SpatialMenuUI.cs
@@ -26,6 +26,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const string k_ExternalRayBasedInputModeName = "Ray Input Mode";
         const string k_TriggerRotationInputModeName = "Thumb Rotation Input Mode";
 
+#pragma warning disable 649
         [Tooltip("Scales the amount of delay before the menu will reposition itself (higher is faster)")]
         [SerializeField]
         float m_AdaptiveRepositionRate = 1f;
@@ -112,6 +113,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         Renderer m_ReturnToPreviousBackgroundRenderer;
+#pragma warning restore 649
 
         readonly List<SpatialMenuElement> m_CurrentlyDisplayedMenuElements = new List<SpatialMenuElement>();
 

--- a/Menus/SpatialUI/SpatialMenu/SpatialMenu.cs
+++ b/Menus/SpatialUI/SpatialMenu/SpatialMenu.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using UnityEditor.Experimental.EditorVR.Core;
 using UnityEditor.Experimental.EditorVR.Extensions;
 using UnityEditor.Experimental.EditorVR.Menus;
+using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEngine;
 using UnityEngine.InputNew;
 
@@ -233,7 +234,7 @@ namespace UnityEditor.Experimental.EditorVR
         {
             if (s_SpatialMenuUI == null)
             {
-                s_SpatialMenuUI = this.InstantiateUI(m_SpatialMenuUiPrefab.gameObject, VRView.cameraRig, rayOrigin: rayOrigin).GetComponent<SpatialMenuUI>();
+                s_SpatialMenuUI = this.InstantiateUI(m_SpatialMenuUiPrefab.gameObject, CameraUtils.GetCameraRig(), rayOrigin: rayOrigin).GetComponent<SpatialMenuUI>();
                 s_SpatialMenuUI.spatialMenuData = k_SpatialMenuData; // set shared reference to menu name/type, elements, and highlighted state
                 s_SpatialMenuUI.Setup();
                 s_SpatialMenuUI.returnToPreviousMenuLevel = ReturnToPreviousMenuLevel;

--- a/Menus/SpatialUI/SpatialMenu/SpatialMenu.cs
+++ b/Menus/SpatialUI/SpatialMenu/SpatialMenu.cs
@@ -57,15 +57,19 @@ namespace UnityEditor.Experimental.EditorVR
             NavigatingSubMenuContent,
         }
 
+        static readonly List<SpatialMenuData> k_SpatialMenuData = new List<SpatialMenuData>();
+        static readonly List<Transform> k_AllSpatialMenuRayOrigins = new List<Transform>();
+        static readonly List<ISpatialMenuProvider> k_SpatialMenuProviders = new List<ISpatialMenuProvider>();
+
         static SpatialMenu s_ControllingSpatialMenu;
         static SpatialMenuUI s_SpatialMenuUI;
-        static readonly List<SpatialMenuData> s_SpatialMenuData = new List<SpatialMenuData>();
-        static readonly List<Transform> s_AllSpatialMenuRayOrigins = new List<Transform>();
         static int s_SubMenuElementCount;
         static SpatialMenuData s_SubMenuData;
-        static readonly List<ISpatialMenuProvider> s_SpatialMenuProviders = new List<ISpatialMenuProvider>();
         static SpatialMenuState s_SpatialMenuState;
 
+        static int subMenuElementCount { get { return s_SubMenuData.spatialMenuElements.Count; } }
+
+#pragma warning disable 649
         [SerializeField]
         SpatialMenuUI m_SpatialMenuUiPrefab;
 
@@ -81,6 +85,7 @@ namespace UnityEditor.Experimental.EditorVR
 
         [SerializeField]
         HapticPulse m_NavigateBackPulse;
+#pragma warning restore 649
 
         bool m_Visible;
 
@@ -108,8 +113,6 @@ namespace UnityEditor.Experimental.EditorVR
         float m_TotalShowMenuCircularInputRotation;
         Coroutine m_CircularTriggerSelectionCyclingCoroutine;
         Transform m_RayOrigin;
-
-        int subMenuElementCount { get { return s_SubMenuData.spatialMenuElements.Count; } }
 
         bool visible
         {
@@ -154,7 +157,7 @@ namespace UnityEditor.Experimental.EditorVR
                         s_SubMenuData = null;
                         break;
                     case SpatialMenuState.NavigatingSubMenuContent:
-                        s_SubMenuData = s_SpatialMenuData.FirstOrDefault(x => x.highlighted);
+                        s_SubMenuData = k_SpatialMenuData.FirstOrDefault(x => x.highlighted);
                         this.Pulse(Node.None, m_MenuOpenPulse);
                         break;
                     case SpatialMenuState.Hidden:
@@ -184,8 +187,8 @@ namespace UnityEditor.Experimental.EditorVR
                 // has begun pointing at the spatial UI, which will override the input typs to ray-based interaction
                 // (taking the opposite hand, and pointing it at the menu)
 
-                if (!s_AllSpatialMenuRayOrigins.Contains(m_RayOrigin))
-                    s_AllSpatialMenuRayOrigins.Add(m_RayOrigin);
+                if (!k_AllSpatialMenuRayOrigins.Contains(m_RayOrigin))
+                    k_AllSpatialMenuRayOrigins.Add(m_RayOrigin);
             }
         }
 
@@ -231,7 +234,7 @@ namespace UnityEditor.Experimental.EditorVR
             if (s_SpatialMenuUI == null)
             {
                 s_SpatialMenuUI = this.InstantiateUI(m_SpatialMenuUiPrefab.gameObject, VRView.cameraRig, rayOrigin: rayOrigin).GetComponent<SpatialMenuUI>();
-                s_SpatialMenuUI.spatialMenuData = s_SpatialMenuData; // set shared reference to menu name/type, elements, and highlighted state
+                s_SpatialMenuUI.spatialMenuData = k_SpatialMenuData; // set shared reference to menu name/type, elements, and highlighted state
                 s_SpatialMenuUI.Setup();
                 s_SpatialMenuUI.returnToPreviousMenuLevel = ReturnToPreviousMenuLevel;
                 s_SpatialMenuUI.changeMenuState = ChangeMenuState;
@@ -249,26 +252,26 @@ namespace UnityEditor.Experimental.EditorVR
 
         void RefreshProviderData()
         {
-            foreach (var provider in s_SpatialMenuProviders)
+            foreach (var provider in k_SpatialMenuProviders)
             {
                 foreach (var menuData in provider.spatialMenuData)
                 {
                     // Prevent menus/tools/etc that are instantiated multiple times from adding their contents to the Spatial Menu
-                    if (!s_SpatialMenuData.Any(existingData => String.Equals(existingData.spatialMenuName, menuData.spatialMenuName)))
-                        s_SpatialMenuData.Add(menuData);
+                    if (!k_SpatialMenuData.Any(existingData => String.Equals(existingData.spatialMenuName, menuData.spatialMenuName)))
+                        k_SpatialMenuData.Add(menuData);
                 }
             }
         }
 
         public static void AddProvider(ISpatialMenuProvider provider)
         {
-            if (s_SpatialMenuProviders.Contains(provider))
+            if (k_SpatialMenuProviders.Contains(provider))
                 return;
 
-            s_SpatialMenuProviders.Add(provider);
+            k_SpatialMenuProviders.Add(provider);
 
             foreach (var menuElementSet in provider.spatialMenuData)
-                s_SpatialMenuData.Add(menuElementSet);
+                k_SpatialMenuData.Add(menuElementSet);
         }
 
         void ReturnToPreviousMenuLevel()
@@ -288,7 +291,7 @@ namespace UnityEditor.Experimental.EditorVR
             var divergenceThresholdConvertedToDot = Mathf.Sin(Mathf.Deg2Rad * kDivergenceThreshold);
             var spatialMenuUITransformPosition = s_SpatialMenuUI.adaptiveTransform != null ? s_SpatialMenuUI.adaptiveTransform.position : Vector3.zero;
             var viewerScale = this.GetViewerScale();
-            foreach (var origin in s_AllSpatialMenuRayOrigins)
+            foreach (var origin in k_AllSpatialMenuRayOrigins)
             {
                 if (origin == null)
                     continue;
@@ -377,7 +380,7 @@ namespace UnityEditor.Experimental.EditorVR
                 spatialMenuState = SpatialMenuState.NavigatingTopLevel;
                 s_SpatialMenuUI.spatialInterfaceInputMode = SpatialUIView.SpatialInterfaceInputMode.Neutral;
 
-                foreach (var data in s_SpatialMenuData)
+                foreach (var data in k_SpatialMenuData)
                 {
                     foreach (var element in data.spatialMenuElements)
                     {
@@ -510,7 +513,7 @@ namespace UnityEditor.Experimental.EditorVR
             if (s_SpatialMenuState == SpatialMenuState.NavigatingTopLevel)
             {
                 // User should return to the previously highligted position at this depth of the SpatialMenu
-                var menuElementCount = s_SpatialMenuData.Count;
+                var menuElementCount = k_SpatialMenuData.Count;
                 m_HighlightedTopLevelMenuElementPosition = (int)Mathf.Repeat(m_HighlightedTopLevelMenuElementPosition + elementPositionOffset, menuElementCount);
                 s_SpatialMenuUI.HighlightElementInCurrentlyDisplayedMenuSection(m_HighlightedTopLevelMenuElementPosition);
             }

--- a/Menus/ToolsMenu/Scripts/HintIcon.cs
+++ b/Menus/ToolsMenu/Scripts/HintIcon.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 {
     public class HintIcon : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         bool m_HideOnInitialize = true;
 
@@ -32,6 +33,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         bool m_SlightlyRandomizeHideDuration = true;
+#pragma warning restore 649
 
         readonly Vector3 k_HiddenScale = Vector3.zero;
 

--- a/Menus/ToolsMenu/Scripts/HintLine.cs
+++ b/Menus/ToolsMenu/Scripts/HintLine.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
     {
         const string k_ShaderLineRadiusPropertyName = "_lineRadius";
 
+#pragma warning disable 649
         [SerializeField]
         VRLineRenderer m_ScrollLineRenderer;
 
@@ -20,6 +21,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         MeshRenderer m_MeshRenderer;
+#pragma warning restore 649
 
         Coroutine m_ScrollArrowPulseCoroutine;
         float m_PulseDuration;

--- a/Menus/ToolsMenu/Scripts/ToolsMenuUI.cs
+++ b/Menus/ToolsMenu/Scripts/ToolsMenuUI.cs
@@ -19,6 +19,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const float k_RaySelectIconHighlightedZOffset = -0.0075f;
         const float k_SpatialSelectIconHighlightedZOffset = -0.02f;
 
+#pragma warning disable 649
         [SerializeField]
         Transform m_ButtonContainer;
 
@@ -31,6 +32,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         Transform m_ButtonTooltipTarget;
+#pragma warning restore 649
 
         bool m_AllButtonsVisible;
         List<IToolsMenuButton> m_OrderedButtons;

--- a/Menus/ToolsMenu/ToolsMenu.cs
+++ b/Menus/ToolsMenu/ToolsMenu.cs
@@ -18,6 +18,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const int k_ActiveToolOrderPosition = 1; // A active-tool button position used in this particular ToolButton implementation
         const int k_MaxButtonCount = 16;
 
+#pragma warning disable 649
         [SerializeField]
         Sprite m_MainMenuIcon;
 
@@ -38,6 +39,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         HapticPulse m_HidingPulse; // The pulse performed when ending a spatial selection
+#pragma warning restore 649
 
         float m_AllowToolToggleBeforeThisTime;
         Vector3 m_SpatialScrollStartPosition;

--- a/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.cs
+++ b/Menus/ToolsMenu/ToolsMenuButton/ToolsMenuButton.cs
@@ -21,6 +21,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const string k_MaterialStencilRefProperty = "_StencilRef";
         readonly Vector3 k_ToolButtonActivePosition = new Vector3(0f, 0f, -0.035f);
 
+#pragma warning disable 649
         [SerializeField]
         GradientButton m_GradientButton;
 
@@ -71,6 +72,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         Image m_ButtonIcon;
+#pragma warning restore 649
 
         Coroutine m_PositionCoroutine;
         Coroutine m_VisibilityCoroutine;

--- a/Menus/UndoMenu/Scripts/UndoMenuUI.cs
+++ b/Menus/UndoMenu/Scripts/UndoMenuUI.cs
@@ -13,11 +13,13 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const float k_UndoPerformedAlpha = 1f;
         const string k_MaterialColorProperty = "_Color";
 
+#pragma warning disable 649
         [SerializeField]
         MeshRenderer m_UndoButtonMeshRenderer;
 
         [SerializeField]
         MeshRenderer m_RedoButtonMeshRenderer;
+#pragma warning restore 649
 
         Material m_UndoButtonMaterial;
         Material m_RedoButtonMaterial;

--- a/Menus/UndoMenu/UndoMenu.cs
+++ b/Menus/UndoMenu/UndoMenu.cs
@@ -18,6 +18,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
         const string k_FeedbackHintForJoystickController = "Click + flick left/right to undo/redo";
         const string k_FeedbackHintForTrackpadController = "Click left/right side to undo/redo";
 
+#pragma warning disable 649
         [SerializeField]
         ActionMap m_ActionMap;
 
@@ -26,6 +27,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         HapticPulse m_UndoPulse;
+#pragma warning restore 649
 
         UndoMenuUI m_UndoMenuUI;
         Transform m_AlternateMenuOrigin;

--- a/Scripts/Core/Contexts/EditingContextManager.cs
+++ b/Scripts/Core/Contexts/EditingContextManager.cs
@@ -17,8 +17,10 @@ namespace UnityEditor.Experimental.EditorVR.Core
 #endif
     sealed class EditingContextManager : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         UnityObject m_DefaultContext;
+#pragma warning restore 649
 
         internal const string k_SettingsPath = "ProjectSettings/EditingContextManagerSettings.asset";
         internal const string k_UserSettingsPath = "Library/EditingContextManagerSettings.asset";

--- a/Scripts/Core/Contexts/EditingContextManager.cs
+++ b/Scripts/Core/Contexts/EditingContextManager.cs
@@ -22,8 +22,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
         UnityObject m_DefaultContext;
 #pragma warning restore 649
 
-        internal const string k_SettingsPath = "ProjectSettings/EditingContextManagerSettings.asset";
-        internal const string k_UserSettingsPath = "Library/EditingContextManagerSettings.asset";
+        internal const string settingsPath = "ProjectSettings/EditingContextManagerSettings.asset";
+        internal const string userSettingsPath = "Library/EditingContextManagerSettings.asset";
 
         const string k_AutoOpen = "EditorXR.EditingContextManager.AutoOpen";
         const string k_LaunchOnExitPlaymode = "EditorXR.EditingContextManager.LaunchOnExitPlaymode";
@@ -35,9 +35,12 @@ namespace UnityEditor.Experimental.EditorVR.Core
         static List<IEditingContext> s_AvailableContexts;
         static EditingContextManagerSettings s_Settings;
         static UnityObject s_DefaultContext;
+
+#if UNITY_EDITOR
         static bool s_AutoOpened;
         static bool s_UserWasPresent;
         static bool s_EnableXRFailed;
+#endif
 
         string[] m_ContextNames;
         int m_SelectedContextIndex;
@@ -109,7 +112,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
         static void OnVRViewDisabled()
         {
+#if UNITY_EDITOR
             s_AutoOpened = false;
+#endif
             ObjectUtils.Destroy(s_Instance.gameObject);
             if (s_InputManager)
                 ObjectUtils.Destroy(s_InputManager.gameObject);
@@ -449,8 +454,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
         internal static EditingContextManagerSettings LoadProjectSettings()
         {
             EditingContextManagerSettings settings = ScriptableObject.CreateInstance<EditingContextManagerSettings>();
-            if (File.Exists(k_SettingsPath))
-                JsonUtility.FromJsonOverwrite(File.ReadAllText(k_SettingsPath), settings);
+            if (File.Exists(settingsPath))
+                JsonUtility.FromJsonOverwrite(File.ReadAllText(settingsPath), settings);
 
             return settings;
         }
@@ -458,11 +463,11 @@ namespace UnityEditor.Experimental.EditorVR.Core
         internal static EditingContextManagerSettings LoadUserSettings()
         {
             EditingContextManagerSettings settings;
-            if (File.Exists(k_UserSettingsPath)
-                && File.GetLastWriteTime(k_UserSettingsPath) > File.GetLastWriteTime(k_SettingsPath))
+            if (File.Exists(userSettingsPath)
+                && File.GetLastWriteTime(userSettingsPath) > File.GetLastWriteTime(settingsPath))
             {
                 settings = ScriptableObject.CreateInstance<EditingContextManagerSettings>();
-                JsonUtility.FromJsonOverwrite(File.ReadAllText(k_UserSettingsPath), settings);
+                JsonUtility.FromJsonOverwrite(File.ReadAllText(userSettingsPath), settings);
             }
             else
                 settings = LoadProjectSettings();
@@ -473,24 +478,24 @@ namespace UnityEditor.Experimental.EditorVR.Core
         internal static void ResetProjectSettings()
         {
 #if UNITY_EDITOR
-            File.Delete(k_UserSettingsPath);
+            File.Delete(userSettingsPath);
 
             if (EditorUtility.DisplayDialog("Delete Project Settings?", "Would you like to remove the project-wide settings, too?", "Yes", "No"))
-                File.Delete(k_SettingsPath);
+                File.Delete(settingsPath);
 #endif
         }
 
         internal static void SaveProjectSettings(EditingContextManagerSettings settings)
         {
 #if UNITY_EDITOR
-            File.WriteAllText(k_SettingsPath, JsonUtility.ToJson(settings, true));
+            File.WriteAllText(settingsPath, JsonUtility.ToJson(settings, true));
 #endif
         }
 
         internal static void SaveUserSettings(EditingContextManagerSettings settings)
         {
 #if UNITY_EDITOR
-            File.WriteAllText(k_UserSettingsPath, JsonUtility.ToJson(settings, true));
+            File.WriteAllText(userSettingsPath, JsonUtility.ToJson(settings, true));
 #endif
         }
 

--- a/Scripts/Core/Contexts/EditorXRContext.cs
+++ b/Scripts/Core/Contexts/EditorXRContext.cs
@@ -10,6 +10,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
     [CreateAssetMenu(menuName = "EditorXR/Editing Context")]
     class EditorXRContext : ScriptableObject, IEditingContext
     {
+        static EditorVR s_Instance; // Used only by PreferencesGUI
+
+#pragma warning disable 649
         [SerializeField]
         float m_RenderScale = 1f;
 
@@ -51,9 +54,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
         [SerializeField]
         [HideInInspector]
         List<string> m_HiddenTypeNames;
+#pragma warning restore 649
 
         EditorVR m_Instance;
-        static EditorVR s_Instance; // Used only by PreferencesGUI
 
         public bool copyMainCameraSettings { get { return m_CopyMainCameraSettings; } }
 

--- a/Scripts/Core/EditorVR.Rays.cs
+++ b/Scripts/Core/EditorVR.Rays.cs
@@ -12,11 +12,13 @@ namespace UnityEditor.Experimental.EditorVR.Core
 {
     partial class EditorVR
     {
+#pragma warning disable 649
         [SerializeField]
         DefaultProxyRay m_ProxyRayPrefab;
 
         [SerializeField]
         ProxyExtras m_ProxyExtras;
+#pragma warning restore 649
 
         class Rays : Nested, IInterfaceConnector, IForEachRayOrigin, IConnectInterfaces, IStandardIgnoreList
         {

--- a/Scripts/Core/EditorVR.UI.cs
+++ b/Scripts/Core/EditorVR.UI.cs
@@ -9,8 +9,10 @@ namespace UnityEditor.Experimental.EditorVR.Core
 {
     partial class EditorVR
     {
+#pragma warning disable 649
         [SerializeField]
         Camera m_EventCameraPrefab;
+#pragma warning restore 649
 
         class UI : Nested, IInterfaceConnector, IConnectInterfaces
         {
@@ -137,7 +139,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
                 return false;
             }
 
-            internal void UpdateManipulatorVisibilites()
+            internal void UpdateManipulatorVisibilities()
             {
                 var manipulatorsVisible = m_ManipulatorsHiddenRequests.Count == 0;
                 foreach (var controller in m_ManipulatorControllers)

--- a/Scripts/Core/EditorVR.Viewer.cs
+++ b/Scripts/Core/EditorVR.Viewer.cs
@@ -11,6 +11,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 {
     partial class EditorVR
     {
+#pragma warning disable 649
         [SerializeField]
         GameObject m_PlayerModelPrefab;
 
@@ -19,6 +20,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
         [SerializeField]
         GameObject m_PreviewCameraPrefab;
+#pragma warning restore 649
 
         class Viewer : Nested, IInterfaceConnector, ISerializePreferences, IConnectInterfaces
         {

--- a/Scripts/Core/EditorVR.Viewer.cs
+++ b/Scripts/Core/EditorVR.Viewer.cs
@@ -87,7 +87,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
                 IUsesViewerScaleMethods.setViewerScale = SetViewerScale;
                 IGetVRPlayerObjectsMethods.getVRPlayerObjects = () => m_VRPlayerObjects;
 
+#if UNITY_EDITOR
                 VRView.hmdStatusChange += OnHMDStatusChange;
+#endif
 
                 preserveCameraRig = true;
 
@@ -98,7 +100,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
             {
                 base.OnDestroy();
 
+#if UNITY_EDITOR
                 VRView.hmdStatusChange -= OnHMDStatusChange;
+#endif
 
                 var cameraRig = CameraUtils.GetCameraRig();
                 if (cameraRig)
@@ -182,12 +186,15 @@ namespace UnityEditor.Experimental.EditorVR.Core
                     cameraRig.localPosition = Vector3.zero;
                 }
 
+#if UNITY_EDITOR
                 var hmdOnlyLayerMask = 0;
+#endif
                 if (!Application.isPlaying && evr.m_PreviewCameraPrefab)
                 {
                     var go = ObjectUtils.Instantiate(evr.m_PreviewCameraPrefab);
                     go.transform.SetParent(CameraUtils.GetCameraRig(), false);
 
+#if UNITY_EDITOR
                     customPreviewCamera = go.GetComponentInChildren<IPreviewCamera>();
                     if (customPreviewCamera != null)
                     {
@@ -196,7 +203,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
                         hmdOnlyLayerMask = customPreviewCamera.hmdOnlyLayerMask;
                         this.ConnectInterfaces(customPreviewCamera);
                     }
+#endif
                 }
+
 #if UNITY_EDITOR
                 VRView.cullingMask = UnityEditor.Tools.visibleLayers | hmdOnlyLayerMask;
 #endif
@@ -204,8 +213,10 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
             internal void UpdateCamera()
             {
+#if UNITY_EDITOR
                 if (customPreviewCamera != null)
                     customPreviewCamera.enabled = VRView.showDeviceView && VRView.customPreviewCamera != null;
+#endif
             }
 
             internal void AddPlayerFloor()

--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -423,7 +423,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
             GetNestedModule<Menus>().UpdateMenuVisibilities();
 
-            GetNestedModule<UI>().UpdateManipulatorVisibilites();
+            GetNestedModule<UI>().UpdateManipulatorVisibilities();
         }
 
         void ProcessInput(HashSet<IProcessInput> processedInputs, ConsumeControlDelegate consumeControl)

--- a/Scripts/Core/VRView.cs
+++ b/Scripts/Core/VRView.cs
@@ -32,7 +32,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
 #if UNITY_EDITOR
         DrawCameraMode m_RenderMode = DrawCameraMode.Textured;
-#endif
 
         // To allow for alternate previews (e.g. smoothing)
         public static Camera customPreviewCamera
@@ -42,10 +41,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
             {
                 if (s_ActiveView != null)
                 {
-#if UNITY_EDITOR
+
                     if (s_ExistingSceneMainCamera && !s_ActiveView.m_CustomPreviewCamera && EditingContextManager.defaultContext.copyMainCameraImageEffectsToPresentationCamera)
                         CopyImagesEffectsToCamera(value);
-#endif
 
                     s_ActiveView.m_CustomPreviewCamera = value;
                 }
@@ -59,10 +57,9 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
         LayerMask? m_CullingMask;
         RenderTexture m_TargetTexture;
+
         bool m_ShowDeviceView;
-#if UNITY_EDITOR
         EditorWindow[] m_EditorWindows;
-#endif
 
         static VRView s_ActiveView;
 
@@ -114,6 +111,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
                     s_ActiveView.m_CullingMask = value;
             }
         }
+#endif
 
         public static Vector3 headCenteredOrigin
         {
@@ -127,11 +125,13 @@ namespace UnityEditor.Experimental.EditorVR.Core
             }
         }
 
+#if UNITY_EDITOR
         public static event Action viewEnabled;
         public static event Action viewDisabled;
         public static event Action<VRView> beforeOnGUI;
         public static event Action<VRView> afterOnGUI;
         public static event Action<bool> hmdStatusChange;
+#endif
 
         public Rect guiRect { get; private set; }
 
@@ -140,17 +140,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
         public static bool LeftMouseButtonHeld;
         public static bool MiddleMouseButtonHeld;
         public static bool RightMouseButtonHeld;
-
-        public static Coroutine StartCoroutine(IEnumerator routine)
-        {
-            if (s_ActiveView != null && s_ActiveView.m_CameraRig)
-            {
-                var mb = s_ActiveView.m_CameraRig.GetComponent<EditorMonoBehaviour>();
-                return mb.StartCoroutine(routine);
-            }
-
-            return null;
-        }
 
         public static void CreateCameraRig(ref Camera camera, ref Transform cameraRig)
         {

--- a/Scripts/Data/AssetData.cs
+++ b/Scripts/Data/AssetData.cs
@@ -6,7 +6,9 @@ namespace UnityEditor.Experimental.EditorVR.Data
 {
     sealed class AssetData : ListViewItemData<int>
     {
-        const string k_TemplateName = "AssetGridItem";
+        public const string PrefabTypeString = "Prefab";
+        public const string ModelTypeString = "Model";
+        static readonly string k_TemplateName = "AssetGridItem";
 
         public string guid { get; private set; }
 
@@ -43,13 +45,21 @@ namespace UnityEditor.Experimental.EditorVR.Data
             if (type == "GameObject")
             {
 #if UNITY_EDITOR
+#if UNITY_2018_3_OR_NEWER
+                switch (PrefabUtility.GetPrefabAssetType(asset))
+#else
                 switch (PrefabUtility.GetPrefabType(asset))
+#endif
                 {
+#if UNITY_2018_3_OR_NEWER
+                    case PrefabAssetType.Model:
+#else
                     case PrefabType.ModelPrefab:
-                        type = "Model";
+#endif
+                        type = ModelTypeString;
                         break;
                     default:
-                        type = "Prefab";
+                        type = PrefabTypeString;
                         break;
                 }
 #endif

--- a/Scripts/Data/DefaultScriptReferences.cs
+++ b/Scripts/Data/DefaultScriptReferences.cs
@@ -102,7 +102,11 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
             if (!Directory.Exists(directory))
                 Directory.CreateDirectory(directory);
 
+#if UNITY_2018_3_OR_NEWER
+            defaultScriptReferences.m_ScriptPrefab = PrefabUtility.SaveAsPrefabAsset(prefabsRoot, Path.ChangeExtension(k_Path, "prefab"));
+#else
             defaultScriptReferences.m_ScriptPrefab = PrefabUtility.CreatePrefab(Path.ChangeExtension(k_Path, "prefab"), prefabsRoot);
+#endif
             defaultScriptReferences.m_EditingContexts = EditingContextManager.GetEditingContextAssets().ConvertAll(ec => (ScriptableObject)ec);
 
             AssetDatabase.CreateAsset(defaultScriptReferences, k_Path);

--- a/Scripts/Data/DefaultScriptReferences.cs
+++ b/Scripts/Data/DefaultScriptReferences.cs
@@ -14,11 +14,13 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
         const string k_ResourcesFolder = "Resources";
         const string k_Path = k_ParentFolder + "/" + k_ResourcesFolder + "/DefaultScriptReferences.asset";
 
+#pragma warning disable 649
         [SerializeField]
         GameObject m_ScriptPrefab;
 
         [SerializeField]
         List<ScriptableObject> m_EditingContexts;
+#pragma warning restore 649
 
         Dictionary<Type, GameObject> m_TypePrefabs = new Dictionary<Type, GameObject>();
 

--- a/Scripts/Handles/LinearHandle.cs
+++ b/Scripts/Handles/LinearHandle.cs
@@ -17,12 +17,14 @@ namespace UnityEditor.Experimental.EditorVR.Handles
             public LinearHandleEventData(Transform rayOrigin, bool direct) : base(rayOrigin, direct) {}
         }
 
+#pragma warning disable 649
         [SerializeField]
         bool m_OrientDragPlaneToRay = true;
 
         [FlagsProperty]
         [SerializeField]
         AxisFlags m_Constraints;
+#pragma warning restore 649
 
         readonly Dictionary<Transform, Vector3> m_LastPositions = new Dictionary<Transform, Vector3>(k_DefaultCapacity);
 

--- a/Scripts/Handles/PlaneHandle.cs
+++ b/Scripts/Handles/PlaneHandle.cs
@@ -17,9 +17,11 @@ namespace UnityEditor.Experimental.EditorVR.Handles
             public PlaneHandleEventData(Transform rayOrigin, bool direct) : base(rayOrigin, direct) {}
         }
 
+#pragma warning disable 649
         [FlagsProperty]
         [SerializeField]
         AxisFlags m_Constraints;
+#pragma warning restore 649
 
         Plane m_Plane;
         readonly Dictionary<Transform, Vector3> m_LastPositions = new Dictionary<Transform, Vector3>(k_DefaultCapacity);

--- a/Scripts/Handles/RadialHandle.cs
+++ b/Scripts/Handles/RadialHandle.cs
@@ -14,8 +14,10 @@ namespace UnityEditor.Experimental.EditorVR.Handles
             public RadialHandleEventData(Transform rayOrigin, bool direct) : base(rayOrigin, direct) {}
         }
 
+#pragma warning disable 649
         [SerializeField]
         float m_TurnSpeed;
+#pragma warning restore 649
 
         Plane m_Plane;
         readonly Dictionary<Transform, Vector3> m_LastPositions = new Dictionary<Transform, Vector3>(k_DefaultCapacity);

--- a/Scripts/Handles/UI/DropDown.cs
+++ b/Scripts/Handles/UI/DropDown.cs
@@ -18,32 +18,9 @@ namespace UnityEditor.Experimental.EditorVR.UI
 {
     sealed class DropDown : MonoBehaviour
     {
-        Coroutine m_ShowDropdownCoroutine;
-        Coroutine m_HideDropdownCoroutine;
-        float m_HiddenDropdownItemYSpacing;
-        float m_VisibleDropdownItemYSpacing;
-        float m_VisibleBackgroundMeshLocalYScale;
-        float m_PreviousXRotation;
-        Vector3 m_OptionsPanelOriginalLocalPosition;
-
-        public string[] options
-        {
-            get { return m_Options; }
-            set
-            {
-                m_Options = value;
-                SetupOptions();
-            }
-        }
-
+#pragma warning disable 649
         [SerializeField]
         string[] m_Options;
-
-        public bool multiSelect
-        {
-            get { return m_MultiSelect; }
-            set { m_MultiSelect = value; }
-        }
 
         [SerializeField]
         bool m_MultiSelect;
@@ -71,18 +48,24 @@ namespace UnityEditor.Experimental.EditorVR.UI
         [SerializeField]
         Transform m_BackgroundMeshTransform;
 
-        public int value
-        {
-            get { return m_Value; }
-            set
-            {
-                m_Value = value;
-                UpdateLabel();
-            }
-        }
-
         [SerializeField]
         int m_Value;
+
+        [SerializeField]
+        int[] m_Values = new int[0];
+#pragma warning restore 649
+
+        Coroutine m_ShowDropdownCoroutine;
+        Coroutine m_HideDropdownCoroutine;
+        float m_HiddenDropdownItemYSpacing;
+        float m_VisibleDropdownItemYSpacing;
+        float m_VisibleBackgroundMeshLocalYScale;
+        float m_PreviousXRotation;
+        Vector3 m_OptionsPanelOriginalLocalPosition;
+
+        Toggle[] m_Toggles;
+
+        public event Action<int, int[]> valueChanged;
 
         public int[] values
         {
@@ -95,12 +78,31 @@ namespace UnityEditor.Experimental.EditorVR.UI
             }
         }
 
-        [SerializeField]
-        int[] m_Values = new int[0];
+        public bool multiSelect
+        {
+            get { return m_MultiSelect; }
+            set { m_MultiSelect = value; }
+        }
 
-        Toggle[] m_Toggles;
+        public int value
+        {
+            get { return m_Value; }
+            set
+            {
+                m_Value = value;
+                UpdateLabel();
+            }
+        }
 
-        public event Action<int, int[]> valueChanged;
+        public string[] options
+        {
+            get { return m_Options; }
+            set
+            {
+                m_Options = value;
+                SetupOptions();
+            }
+        }
 
         void Awake()
         {

--- a/Scripts/Handles/UI/KeyboardButton.cs
+++ b/Scripts/Handles/UI/KeyboardButton.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections;
 using TMPro;
-using UnityEngine;
-using UnityEngine.UI;
+using UnityEditor.Experimental.EditorVR.Extensions;
 using UnityEditor.Experimental.EditorVR.Handles;
 using UnityEditor.Experimental.EditorVR.Helpers;
 using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEditor.Experimental.EditorVR.Workspaces;
-using UnityEditor.Experimental.EditorVR.Extensions;
+using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.UI
 {
@@ -30,40 +29,9 @@ namespace UnityEditor.Experimental.EditorVR.UI
         const float k_KeyResponsePositionAmplitude = 0.02f;
         const float k_KeyResponseScaleAmplitude = 0.08f;
 
-        public TextMeshProUGUI textComponent
-        {
-            get { return m_TextComponent; }
-            set { m_TextComponent = value; }
-        }
-
+#pragma warning disable 649
         [SerializeField]
         TextMeshProUGUI m_TextComponent;
-
-        public Material targetMeshMaterial
-        {
-            get { return m_TargetMeshMaterial; }
-        }
-
-        Material m_TargetMeshMaterial;
-
-        public Color targetMeshBaseColor
-        {
-            get { return m_TargetMeshBaseColor; }
-        }
-
-        Color m_TargetMeshBaseColor;
-
-        public CanvasGroup canvasGroup
-        {
-            get
-            {
-                return !m_CanvasGroup
-                    ? GetComponentInChildren<CanvasGroup>(true)
-                    : m_CanvasGroup;
-            }
-        }
-
-        CanvasGroup m_CanvasGroup;
 
         [SerializeField]
         char m_Character;
@@ -87,6 +55,13 @@ namespace UnityEditor.Experimental.EditorVR.UI
 
         [SerializeField]
         WorkspaceButton m_WorkspaceButton;
+#pragma warning restore 649
+
+        Material m_TargetMeshMaterial;
+
+        Color m_TargetMeshBaseColor;
+
+        CanvasGroup m_CanvasGroup;
 
         float m_HoldStartTime;
         float m_RepeatWaitTime;
@@ -101,6 +76,32 @@ namespace UnityEditor.Experimental.EditorVR.UI
         Action<char> m_KeyPress;
         Func<bool> m_PressOnHover;
         Func<bool> m_InTransition;
+
+        public TextMeshProUGUI textComponent
+        {
+            get { return m_TextComponent; }
+            set { m_TextComponent = value; }
+        }
+
+        public Material targetMeshMaterial
+        {
+            get { return m_TargetMeshMaterial; }
+        }
+
+        public Color targetMeshBaseColor
+        {
+            get { return m_TargetMeshBaseColor; }
+        }
+
+        public CanvasGroup canvasGroup
+        {
+            get
+            {
+                return !m_CanvasGroup
+                    ? GetComponentInChildren<CanvasGroup>(true)
+                    : m_CanvasGroup;
+            }
+        }
 
         void Awake()
         {

--- a/Scripts/Helpers/EditorMonoBehaviour.cs
+++ b/Scripts/Helpers/EditorMonoBehaviour.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections;
+using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Helpers
 {
@@ -7,5 +8,21 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
     /// </summary>
     sealed class EditorMonoBehaviour : MonoBehaviour
     {
+        public static EditorMonoBehaviour instance;
+
+        void Awake()
+        {
+            instance = this;
+        }
+
+        public static Coroutine StartEditorCoroutine(IEnumerator routine)
+        {
+            // Avoid null-coalescing operator for UnityObject
+            // ReSharper disable once ConvertIfStatementToReturnStatement
+            if (instance)
+                return instance.StartCoroutine(routine);
+
+            return null;
+        }
     }
 }

--- a/Scripts/Helpers/EditorWindowCapture.cs
+++ b/Scripts/Helpers/EditorWindowCapture.cs
@@ -19,11 +19,13 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
         // Mouse events are expected to be relative to the window, but our quad only displays the inner GUI
         static readonly Vector2 k_WindowOffset = new Vector2(0, 22f);
 
+#pragma warning disable 649
         [SerializeField]
         string m_WindowClass;
 
         [SerializeField]
         Rect m_Position = new Rect(0f, 0f, 600f, 400f);
+#pragma warning restore 649
 
         EditorWindow m_Window;
         Object m_GuiView;

--- a/Scripts/Helpers/PlayerBody.cs
+++ b/Scripts/Helpers/PlayerBody.cs
@@ -4,11 +4,13 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
 {
     public class PlayerBody : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         Collider m_OverShoulderTrigger;
 
         [SerializeField]
         Collider m_AboveHeadTrigger;
+#pragma warning restore 649
 
         public Collider overShoulderTrigger { get { return m_OverShoulderTrigger; } }
 

--- a/Scripts/Helpers/PlayerFloor.cs
+++ b/Scripts/Helpers/PlayerFloor.cs
@@ -12,6 +12,7 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
         const float k_XOffset = 0.05f;
         const float k_ZOffset = 0.025f;
 
+#pragma warning disable 649
         [SerializeField]
         CanvasGroup m_CanvasGroup;
 
@@ -20,6 +21,7 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
 
         [SerializeField]
         float m_Delay = 2f;
+#pragma warning restore 649
 
         Vector3 m_FloorPosition;
         Transform m_Camera;

--- a/Scripts/Helpers/VRSmoothCamera.cs
+++ b/Scripts/Helpers/VRSmoothCamera.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
 using UnityEditor.Experimental.EditorVR.Core;
 using UnityEngine;
 
@@ -141,3 +142,4 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
         }
     }
 }
+#endif

--- a/Scripts/Helpers/VRSmoothCamera.cs
+++ b/Scripts/Helpers/VRSmoothCamera.cs
@@ -11,23 +11,11 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
     [RequiresLayer(k_HMDOnlyLayer)]
     sealed class VRSmoothCamera : MonoBehaviour, IPreviewCamera
     {
-        /// <summary>
-        /// The camera drawing the preview
-        /// </summary>
-        public Camera previewCamera { get { return m_SmoothCamera; } }
+        static readonly List<bool> k_HiddenEnabled = new List<bool>();
+        const string k_HMDOnlyLayer = "HMDOnly";
+        static readonly Rect k_DefaultCameraRect = new Rect(0f, 0f, 1f, 1f);
 
-        Camera m_SmoothCamera;
-
-        /// <summary>
-        /// The actual HMD camera (will be provided by system)
-        /// The VRView's camera, whose settings are copied by the SmoothCamera
-        /// </summary>
-        public Camera vrCamera
-        {
-            private get { return m_VRCamera; }
-            set { m_VRCamera = value; }
-        }
-
+#pragma warning disable 649
         [SerializeField]
         Camera m_VRCamera;
 
@@ -42,9 +30,9 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
 
         [SerializeField]
         float m_SmoothingMultiplier = 3;
+#pragma warning restore 649
 
-        const string k_HMDOnlyLayer = "HMDOnly";
-        readonly Rect k_DefaultCameraRect = new Rect(0f, 0f, 1f, 1f);
+        Camera m_SmoothCamera;
 
         RenderTexture m_RenderTexture;
 
@@ -52,7 +40,20 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
         Quaternion m_Rotation;
         int m_HMDOnlyLayerMask;
 
-        static readonly List<bool> k_HiddenEnabled = new List<bool>();
+        /// <summary>
+        /// The camera drawing the preview
+        /// </summary>
+        public Camera previewCamera { get { return m_SmoothCamera; } }
+
+        /// <summary>
+        /// The actual HMD camera (will be provided by system)
+        /// The VRView's camera, whose settings are copied by the SmoothCamera
+        /// </summary>
+        public Camera vrCamera
+        {
+            private get { return m_VRCamera; }
+            set { m_VRCamera = value; }
+        }
 
         /// <summary>
         /// A layer mask that controls what will always render in the HMD and not in the preview

--- a/Scripts/ListView/ListViewController.cs
+++ b/Scripts/ListView/ListViewController.cs
@@ -9,6 +9,33 @@ namespace ListView
         where TData : ListViewItemData<TIndex>
         where TItem : ListViewItem<TData, TIndex>
     {
+#pragma warning disable 649
+        [Header("Unassigned haptic pulses will not be performed")]
+        [SerializeField]
+        HapticPulse m_ItemClickPulse;
+
+        [SerializeField]
+        HapticPulse m_ItemHoverStartPulse;
+
+        [SerializeField]
+        HapticPulse m_ItemHoverEndPulse;
+
+        [SerializeField]
+        HapticPulse m_ItemDragStartPulse;
+
+        [SerializeField]
+        HapticPulse m_ItemDraggingPulse;
+
+        [SerializeField]
+        HapticPulse m_ItemDragEndPulse;
+#pragma warning restore 649
+
+        protected List<TData> m_Data;
+
+        protected readonly Dictionary<string, ListViewItemTemplate<TItem>> m_TemplateDictionary = new Dictionary<string, ListViewItemTemplate<TItem>>();
+        protected readonly Dictionary<TIndex, TItem> m_ListItems = new Dictionary<TIndex, TItem>();
+        protected readonly Dictionary<TIndex, Transform> m_GrabbedRows = new Dictionary<TIndex, Transform>();
+
         public virtual List<TData> data
         {
             get { return m_Data; }
@@ -28,31 +55,6 @@ namespace ListView
                 scrollOffset = 0;
             }
         }
-
-        [Header("Unassigned haptic pulses will not be performed")]
-        [SerializeField]
-        HapticPulse m_ItemClickPulse;
-
-        [SerializeField]
-        HapticPulse m_ItemHoverStartPulse;
-
-        [SerializeField]
-        HapticPulse m_ItemHoverEndPulse;
-
-        [SerializeField]
-        HapticPulse m_ItemDragStartPulse;
-
-        [SerializeField]
-        HapticPulse m_ItemDraggingPulse;
-
-        [SerializeField]
-        HapticPulse m_ItemDragEndPulse;
-
-        protected List<TData> m_Data;
-
-        protected readonly Dictionary<string, ListViewItemTemplate<TItem>> m_TemplateDictionary = new Dictionary<string, ListViewItemTemplate<TItem>>();
-        protected readonly Dictionary<TIndex, TItem> m_ListItems = new Dictionary<TIndex, TItem>();
-        protected readonly Dictionary<TIndex, Transform> m_GrabbedRows = new Dictionary<TIndex, Transform>();
 
         protected override float listHeight { get { return m_Data.Count * itemSize.z; } }
 

--- a/Scripts/ListView/ListViewControllerBase.cs
+++ b/Scripts/ListView/ListViewControllerBase.cs
@@ -8,12 +8,7 @@ namespace ListView
 {
     public abstract class ListViewControllerBase : MonoBehaviour, IScrollHandler, IControlHaptics
     {
-        public float scrollOffset
-        {
-            get { return m_ScrollOffset; }
-            set { m_ScrollOffset = value; }
-        }
-
+#pragma warning disable 649
         [Tooltip("Distance (in meters) we have scrolled from initial position")]
         [SerializeField]
         protected float m_ScrollOffset;
@@ -40,28 +35,13 @@ namespace ListView
         [SerializeField]
         protected float m_SettleSpeed = 0.4f;
 
-        public float scrollSpeed
-        {
-            get { return m_ScrollSpeed; }
-            set { m_ScrollSpeed = value; }
-        }
-
         [SerializeField]
         float m_ScrollSpeed = 0.3f;
+#pragma warning restore 649
 
-        protected bool m_Settling;
         event Action settlingCompleted;
 
-        public Vector3 itemSize
-        {
-            get
-            {
-                if (!m_ItemSize.HasValue && m_Templates.Length > 0)
-                    m_ItemSize = GetObjectSize(m_Templates[0]);
-
-                return m_ItemSize ?? Vector3.zero;
-            }
-        }
+        protected bool m_Settling;
 
         protected Vector3? m_ItemSize;
 
@@ -76,6 +56,29 @@ namespace ListView
         protected Vector3 m_Extents;
 
         protected abstract float listHeight { get; }
+
+        public float scrollOffset
+        {
+            get { return m_ScrollOffset; }
+            set { m_ScrollOffset = value; }
+        }
+
+        public float scrollSpeed
+        {
+            get { return m_ScrollSpeed; }
+            set { m_ScrollSpeed = value; }
+        }
+
+        public Vector3 itemSize
+        {
+            get
+            {
+                if (!m_ItemSize.HasValue && m_Templates.Length > 0)
+                    m_ItemSize = GetObjectSize(m_Templates[0]);
+
+                return m_ItemSize ?? Vector3.zero;
+            }
+        }
 
         public virtual Vector3 size
         {

--- a/Scripts/ListView/ListViewScroller.cs
+++ b/Scripts/ListView/ListViewScroller.cs
@@ -4,8 +4,10 @@ using UnityEngine.EventSystems;
 
 public class ListViewScroller : MonoBehaviour, IScrollHandler
 {
+#pragma warning disable 649
     [SerializeField]
     ListViewControllerBase m_ListView;
+#pragma warning restore 649
 
     public void OnScroll(PointerEventData eventData)
     {

--- a/Scripts/Modules/AdaptivePositionModule/AdaptivePositionModule.cs
+++ b/Scripts/Modules/AdaptivePositionModule/AdaptivePositionModule.cs
@@ -9,8 +9,10 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 {
     public sealed class AdaptivePositionModule : MonoBehaviour, IDetectGazeDivergence, IUsesViewerScale, IControlHaptics, ISystemModule
     {
+#pragma warning disable 649
         [SerializeField]
         HapticPulse m_MovingPulse; // The pulse performed while moving an element to a new target position in the user's FOV
+#pragma warning restore 649
 
         bool m_TestInFocus;
         Transform m_GazeTransform;

--- a/Scripts/Modules/DeviceInputModule.cs
+++ b/Scripts/Modules/DeviceInputModule.cs
@@ -20,11 +20,13 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             public int order;
         }
 
+#pragma warning disable 649
         [SerializeField]
         ActionMap m_TrackedObjectActionMap;
 
         [SerializeField]
         ActionMap m_StandardToolActionMap;
+#pragma warning restore 649
 
         PlayerHandle m_PlayerHandle;
 

--- a/Scripts/Modules/DeviceInputModule.cs
+++ b/Scripts/Modules/DeviceInputModule.cs
@@ -1,8 +1,4 @@
-﻿#if !UNITY_2017_2_OR_NEWER
-#pragma warning disable 649 // "never assigned to" warning
-#endif
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor.Experimental.EditorVR.Utilities;

--- a/Scripts/Modules/FeedbackModule/FeedbackModule.cs
+++ b/Scripts/Modules/FeedbackModule/FeedbackModule.cs
@@ -36,14 +36,17 @@ namespace UnityEditor.Experimental.EditorVR
             }
         }
 
+#pragma warning disable 649
         [SerializeField]
         GameObject m_SettingsMenuItemPrefab;
+#pragma warning restore 649
 
         readonly List<Toggle> m_Toggles = new List<Toggle>();
 
         Preferences m_Preferences;
 
         readonly List<IFeedbackReceiver> m_FeedbackReceivers = new List<IFeedbackReceiver>();
+        readonly Dictionary<Type, Queue<FeedbackRequest>> m_FeedbackRequestPool = new Dictionary<Type, Queue<FeedbackRequest>>();
 
         public GameObject settingsMenuItemPrefab { get { return m_SettingsMenuItemPrefab; } }
 
@@ -79,8 +82,6 @@ namespace UnityEditor.Experimental.EditorVR
         }
 
         public Transform rayOrigin { get { return null; } }
-
-        readonly Dictionary<Type, Queue<FeedbackRequest>> m_FeedbackRequestPool = new Dictionary<Type, Queue<FeedbackRequest>>();
 
         void Awake()
         {

--- a/Scripts/Modules/HapticsModule/HapticPulse.cs
+++ b/Scripts/Modules/HapticsModule/HapticPulse.cs
@@ -5,6 +5,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
     [CreateAssetMenu(menuName = "EditorXR/Haptic Pulse", fileName = "NewHapticPulse.asset")]
     public class HapticPulse : ScriptableObject
     {
+#pragma warning disable 649
         [SerializeField]
         [Range(0.001f, 1f)]
         float m_Duration = 0.25f;
@@ -18,6 +19,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
         [SerializeField]
         bool m_FadeOut;
+#pragma warning restore 649
 
         // Don't allow public setting of value; use inspector-set values
         public float duration

--- a/Scripts/Modules/HighlightModule/HighlightModule.cs
+++ b/Scripts/Modules/HighlightModule/HighlightModule.cs
@@ -19,11 +19,13 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
         static readonly Dictionary<SkinnedMeshRenderer, Mesh> k_BakedMeshes = new Dictionary<SkinnedMeshRenderer, Mesh>();
 
+#pragma warning disable 649
         [SerializeField]
         Material m_DefaultHighlightMaterial;
 
         [SerializeField]
         Material m_RayHighlightMaterial;
+#pragma warning restore 649
 
         readonly Dictionary<Material, Dictionary<GameObject, HighlightData>> m_Highlights = new Dictionary<Material, Dictionary<GameObject, HighlightData>>();
         readonly Dictionary<Node, HashSet<Transform>> m_NodeMap = new Dictionary<Node, HashSet<Transform>>();

--- a/Scripts/Modules/IntersectionModule/IntersectionTester.cs
+++ b/Scripts/Modules/IntersectionModule/IntersectionTester.cs
@@ -4,11 +4,13 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 {
     sealed class IntersectionTester : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         Transform[] m_RayTransforms;
 
         [SerializeField]
         bool m_ShowRays;
+#pragma warning restore 649
 
         bool m_Active = true;
         Ray[] m_Rays;
@@ -70,6 +72,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             }
         }
 
+        //TODO: What's up with this?
 #if !UNITY_EDITOR
 #pragma warning disable 109
 #endif

--- a/Scripts/Modules/KeyboardModule.cs
+++ b/Scripts/Modules/KeyboardModule.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 {
     sealed class KeyboardModule : MonoBehaviour, ISystemModule, IRayVisibilitySettings, IForEachRayOrigin, IConnectInterfaces
     {
+#pragma warning disable 649
         [SerializeField]
         KeyboardMallet m_KeyboardMalletPrefab;
 
@@ -17,6 +18,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
         [SerializeField]
         KeyboardUI m_StandardKeyboardPrefab;
+#pragma warning restore 649
 
         readonly Dictionary<Transform, KeyboardMallet> m_KeyboardMallets = new Dictionary<Transform, KeyboardMallet>();
         KeyboardUI m_NumericKeyboard;

--- a/Scripts/Modules/LockModule/LockModule.cs
+++ b/Scripts/Modules/LockModule/LockModule.cs
@@ -19,10 +19,15 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             }
         }
 
+        const float k_MaxHoverTime = 2.0f;
+
+#pragma warning disable 649
         [SerializeField]
         Sprite m_LockIcon;
+
         [SerializeField]
         Sprite m_UnlockIcon;
+#pragma warning restore 649
 
         readonly LockModuleAction m_LockModuleAction = new LockModuleAction();
         public List<IAction> actions { get; private set; }
@@ -34,7 +39,6 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         GameObject m_CurrentHoverObject;
         Transform m_HoverRayOrigin;
         float m_HoverDuration;
-        const float k_MaxHoverTime = 2.0f;
 
         void Awake()
         {

--- a/Scripts/Modules/MultipleRayInputModule/MultipleRayInputModule.cs
+++ b/Scripts/Modules/MultipleRayInputModule/MultipleRayInputModule.cs
@@ -178,12 +178,14 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
         static LayerMask s_LayerMask;
 
+#pragma warning disable 649
+        [SerializeField]
+        ActionMap m_UIActionMap;
+#pragma warning restore 649
+
         readonly Dictionary<Transform, RaycastSource> m_RaycastSources = new Dictionary<Transform, RaycastSource>();
 
         Camera m_EventCamera;
-
-        [SerializeField]
-        ActionMap m_UIActionMap;
 
         public Camera eventCamera
         {

--- a/Scripts/Modules/SceneObjectModule.cs
+++ b/Scripts/Modules/SceneObjectModule.cs
@@ -1,8 +1,4 @@
-﻿#if !UNITY_2017_2_OR_NEWER
-#pragma warning disable 649 // "never assigned to" warning
-#endif
-
-using System;
+﻿using System;
 using System.Collections;
 using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEngine;

--- a/Scripts/Modules/SelectionModule/SelectionModule.cs
+++ b/Scripts/Modules/SelectionModule/SelectionModule.cs
@@ -10,8 +10,10 @@ namespace UnityEditor.Experimental.EditorVR.Modules
     sealed class SelectionModule : MonoBehaviour, ISystemModule, IUsesGameObjectLocking, ISelectionChanged,
         IControlHaptics, IRayToNode, IContainsVRPlayerCompletely
     {
+#pragma warning disable 649
         [SerializeField]
         HapticPulse m_HoverPulse;
+#pragma warning restore 649
 
         GameObject m_CurrentGroupRoot;
         readonly Dictionary<GameObject, GameObject> m_GroupMap = new Dictionary<GameObject, GameObject>(); // Maps objects to their group parent
@@ -135,7 +137,11 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 return groupParent;
 
 #if UNITY_EDITOR
+#if UNITY_2018_3_OR_NEWER
+            var groupRoot = PrefabUtility.GetOutermostPrefabInstanceRoot(hoveredObject);
+#else
             var groupRoot = PrefabUtility.FindPrefabRoot(hoveredObject);
+#endif
 
             if (groupRoot)
                 return groupRoot;

--- a/Scripts/Modules/SnappingModule/SnappingModule.cs
+++ b/Scripts/Modules/SnappingModule/SnappingModule.cs
@@ -39,6 +39,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         const string k_MaterialColorLeftProperty = "_ColorLeft";
         const string k_MaterialColorRightProperty = "_ColorRight";
 
+#pragma warning disable 649
         [SerializeField]
         GameObject m_GroundPlane;
 
@@ -50,6 +51,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
         [SerializeField]
         Material m_ButtonHighlightMaterial;
+#pragma warning restore 649
 
         class SnappingState
         {

--- a/Scripts/Modules/SnappingModule/SnappingModuleSettingsUI.cs
+++ b/Scripts/Modules/SnappingModule/SnappingModuleSettingsUI.cs
@@ -5,6 +5,7 @@ namespace UnityEditor.Experimental.EditorVR
 {
     public class SnappingModuleSettingsUI : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         Toggle m_SnappingEnabled;
 
@@ -28,6 +29,7 @@ namespace UnityEditor.Experimental.EditorVR
 
         [SerializeField]
         Toggle m_DirectSnappingEnabled;
+#pragma warning restore 649
 
         public Toggle snappingEnabled
         {

--- a/Scripts/Modules/SpatialHintModule/SpatialHintUI.cs
+++ b/Scripts/Modules/SpatialHintModule/SpatialHintUI.cs
@@ -10,6 +10,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
     {
         readonly Color k_PrimaryArrowColor = Color.white;
 
+#pragma warning disable 649
         [Header("Scroll Visuals")]
         [SerializeField]
         CanvasGroup m_ScrollVisualsCanvasGroup;
@@ -32,6 +33,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         HintIcon[] m_SecondaryDirectionalHintArrows;
+#pragma warning restore 649
 
         bool m_Visible;
         bool m_PreScrollArrowsVisible;

--- a/Scripts/Modules/SpatialScrollModule/SpatialScrollModule.cs
+++ b/Scripts/Modules/SpatialScrollModule/SpatialScrollModule.cs
@@ -7,12 +7,6 @@ namespace UnityEditor.Experimental.EditorVR.Modules
     public sealed class SpatialScrollModule : MonoBehaviour, ISystemModule, IUsesViewerScale, IControlHaptics,
         IControlSpatialHinting, IRayVisibilitySettings, INodeToRay
     {
-        [SerializeField]
-        HapticPulse m_ActivationPulse; // The pulse performed when initial activating spatial selection
-
-        // Collection housing objects whose scroll data is being processed
-        readonly List<IControlSpatialScrolling> m_ScrollCallers = new List<IControlSpatialScrolling>();
-
         public class SpatialScrollData : INodeToRay
         {
             public SpatialScrollData(IControlSpatialScrolling caller, Node node, Vector3 startingPosition, Vector3 currentPosition, float repeatingScrollLengthRange, int scrollableItemCount, int maxItemCount = -1, bool centerVisuals = true)
@@ -103,6 +97,14 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 currentPosition = newPosition;
             }
         }
+
+#pragma warning disable 649
+        [SerializeField]
+        HapticPulse m_ActivationPulse; // The pulse performed when initial activating spatial selection
+#pragma warning restore 649
+
+        // Collection housing objects whose scroll data is being processed
+        readonly List<IControlSpatialScrolling> m_ScrollCallers = new List<IControlSpatialScrolling>();
 
         internal SpatialScrollData PerformScroll(IControlSpatialScrolling caller, Node node, Vector3 startingPosition, Vector3 currentPosition, float repeatingScrollLengthRange, int scrollableItemCount, int maxItemCount = -1, bool centerScrollVisuals = true)
         {

--- a/Scripts/Modules/TooltipModule/TooltipModule.cs
+++ b/Scripts/Modules/TooltipModule/TooltipModule.cs
@@ -8,27 +8,6 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 {
     sealed class TooltipModule : MonoBehaviour, ISystemModule, IUsesViewerScale
     {
-        const float k_Delay = 0; // In case we want to bring back a delay
-        const float k_TransitionDuration = 0.1f;
-        const float k_UVScale = 100f;
-        const float k_UVScrollSpeed = 1.5f;
-        const float k_Offset = 0.05f;
-        const float k_TextOrientationWeight = 0.1f;
-        const float k_ChangeTransitionDuration = 0.1f;
-
-        const int k_PoolInitialCapacity = 16;
-
-        static readonly Quaternion k_FlipYRotation = Quaternion.AngleAxis(180f, Vector3.up);
-        static readonly Quaternion k_FlipZRotation = Quaternion.AngleAxis(180f, Vector3.forward);
-
-        static readonly Vector3[] k_Corners = new Vector3[4];
-
-        [SerializeField]
-        GameObject m_TooltipPrefab;
-
-        [SerializeField]
-        GameObject m_TooltipCanvasPrefab;
-
         class TooltipData
         {
             public float startTime;
@@ -64,6 +43,29 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 transitionTime = default(float);
             }
         }
+
+        const float k_Delay = 0; // In case we want to bring back a delay
+        const float k_TransitionDuration = 0.1f;
+        const float k_UVScale = 100f;
+        const float k_UVScrollSpeed = 1.5f;
+        const float k_Offset = 0.05f;
+        const float k_TextOrientationWeight = 0.1f;
+        const float k_ChangeTransitionDuration = 0.1f;
+
+        const int k_PoolInitialCapacity = 16;
+
+        static readonly Quaternion k_FlipYRotation = Quaternion.AngleAxis(180f, Vector3.up);
+        static readonly Quaternion k_FlipZRotation = Quaternion.AngleAxis(180f, Vector3.forward);
+
+        static readonly Vector3[] k_Corners = new Vector3[4];
+
+#pragma warning disable 649
+        [SerializeField]
+        GameObject m_TooltipPrefab;
+
+        [SerializeField]
+        GameObject m_TooltipCanvasPrefab;
+#pragma warning restore 649
 
         readonly Dictionary<ITooltip, TooltipData> m_Tooltips = new Dictionary<ITooltip, TooltipData>();
         readonly Queue<TooltipUI> m_TooltipPool = new Queue<TooltipUI>(k_PoolInitialCapacity);

--- a/Scripts/Modules/TooltipModule/TooltipUI.cs
+++ b/Scripts/Modules/TooltipModule/TooltipUI.cs
@@ -16,6 +16,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         const float k_IconTextMinSpacing = 4;
         const float k_IconTextSpacing = 14;
 
+#pragma warning disable 649
         [SerializeField]
         RawImage m_DottedLine;
 
@@ -52,6 +53,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
 
         [SerializeField]
         SkinnedMeshRenderer m_BackgroundOutlineRenderer;
+#pragma warning restore 649
 
         int m_OriginalRightPaddingAmount;
         int m_OriginalTopPaddingAmount;

--- a/Scripts/Proxies/AffordanceTooltipPlacement.cs
+++ b/Scripts/Proxies/AffordanceTooltipPlacement.cs
@@ -7,6 +7,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
     {
         const FacingDirection k_AllDirections = (FacingDirection)0xFFF;
 
+#pragma warning disable 649
         [SerializeField]
         Transform m_TooltipTarget;
 
@@ -19,6 +20,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
         [FlagsProperty]
         [SerializeField]
         FacingDirection m_FacingDirection = k_AllDirections;
+#pragma warning restore 649
 
         public Transform tooltipTarget { get { return m_TooltipTarget; } }
         public Transform tooltipSource { get { return m_TooltipSource; } }

--- a/Scripts/Proxies/Data/Affordance.cs
+++ b/Scripts/Proxies/Data/Affordance.cs
@@ -10,6 +10,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
     [Serializable]
     class Affordance
     {
+#pragma warning disable 649
         [SerializeField]
         VRInputDevice.VRControl m_Control;
 
@@ -25,6 +26,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 
         [SerializeField]
         AffordanceTooltip[] m_Tooltips;
+#pragma warning restore 649
 
         public VRInputDevice.VRControl control { get { return m_Control; } }
         public Transform[] transforms { get { return m_Transforms; } }

--- a/Scripts/Proxies/Data/AffordanceAnimationDefinition.cs
+++ b/Scripts/Proxies/Data/AffordanceAnimationDefinition.cs
@@ -10,6 +10,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
     [Serializable]
     public class AffordanceAnimationDefinition
     {
+#pragma warning disable 649
         [FlagsProperty]
         [SerializeField]
         AxisFlags m_TranslateAxes;
@@ -26,6 +27,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
         [SerializeField]
         bool m_ReverseForRightHand;
+#pragma warning restore 649
 
         /// <summary>
         /// The axes on which to perform translation of an affordance

--- a/Scripts/Proxies/Data/AffordanceVisibilityDefinition.cs
+++ b/Scripts/Proxies/Data/AffordanceVisibilityDefinition.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
     [Serializable]
     public class AffordanceVisibilityDefinition
     {
+#pragma warning disable 649
         [SerializeField]
         ProxyAffordanceMap.VisibilityControlType m_VisibilityType;
 
@@ -26,6 +27,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
         [SerializeField]
         Material m_HiddenMaterial;
+#pragma warning restore 649
 
         /// <summary>
         /// The hidden color of the material

--- a/Scripts/Proxies/Data/ProxyAffordanceMap.cs
+++ b/Scripts/Proxies/Data/ProxyAffordanceMap.cs
@@ -15,6 +15,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
             MaterialSwap
         }
 
+#pragma warning disable 649
         [Header("Non-Interactive Input-Device Body Elements")]
         [SerializeField]
         AffordanceVisibilityDefinition m_BodyVisibilityDefinition;
@@ -29,6 +30,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
         [Header("Custom Affordance Overrides")]
         [SerializeField]
         AffordanceDefinition[] m_AffordanceDefinitions;
+#pragma warning restore 649
 
         /// <summary>
         /// Collection of affordance definitions representing a proxy

--- a/Scripts/Proxies/Data/ProxyExtras.cs
+++ b/Scripts/Proxies/Data/ProxyExtras.cs
@@ -10,6 +10,7 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
     [CreateAssetMenu(menuName = "EditorXR/Proxy Extras")]
     sealed class ProxyExtras : ScriptableObject
     {
+#pragma warning disable 649
         [Serializable]
         struct ProxyExtraData
         {
@@ -23,6 +24,12 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
             /// </summary>
             public GameObject prefab;
         }
+
+        [SerializeField]
+        ProxyExtraData[] m_Extras;
+#pragma warning restore 649
+
+        Dictionary<Node, List<GameObject>> m_Data;
 
         public Dictionary<Node, List<GameObject>> data
         {
@@ -48,10 +55,5 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
                 return m_Data;
             }
         }
-
-        Dictionary<Node, List<GameObject>> m_Data;
-
-        [SerializeField]
-        ProxyExtraData[] m_Extras;
     }
 }

--- a/Scripts/Proxies/DefaultProxyRay.cs
+++ b/Scripts/Proxies/DefaultProxyRay.cs
@@ -15,6 +15,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
             public bool coneVisible;
         }
 
+#pragma warning disable 649
         [SerializeField]
         VRLineRenderer m_LineRenderer;
 
@@ -26,6 +27,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 
         [SerializeField]
         MeshFilter m_Cone;
+#pragma warning restore 649
 
         Vector3 m_TipStartScale;
         Transform m_ConeTransform;

--- a/Scripts/Proxies/ProxyAnimator.cs
+++ b/Scripts/Proxies/ProxyAnimator.cs
@@ -27,8 +27,10 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
             }
         }
 
+#pragma warning disable 649
         [SerializeField]
         ActionMap m_ProxyActionMap;
+#pragma warning restore 649
 
         Affordance[] m_Affordances;
         AffordanceDefinition[] m_AffordanceDefinitions;

--- a/Scripts/Proxies/ProxyNode.cs
+++ b/Scripts/Proxies/ProxyNode.cs
@@ -328,6 +328,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 
         static readonly ProxyFeedbackRequest k_ShakeFeedbackRequest = new ProxyFeedbackRequest { showBody = true };
 
+#pragma warning disable 649
         [SerializeField]
         float m_FadeInDuration = 0.5f;
 
@@ -365,6 +366,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
         [Tooltip("Affordance objects that store transform, renderer, and tooltip references")]
         [SerializeField]
         Affordance[] m_Affordances;
+#pragma warning restore 649
 
         readonly Dictionary<Renderer, AffordanceData> m_AffordanceData = new Dictionary<Renderer, AffordanceData>();
         readonly List<Tuple<Renderer, AffordanceData>> m_BodyData = new List<Tuple<Renderer, AffordanceData>>();

--- a/Scripts/Proxies/Vive/ViveProxy.cs
+++ b/Scripts/Proxies/Vive/ViveProxy.cs
@@ -12,11 +12,13 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 {
     sealed class ViveProxy : TwoHandedProxyBase
     {
+#pragma warning disable 649
         [SerializeField]
         GameObject m_LeftHandTouchProxyPrefab;
 
         [SerializeField]
         GameObject m_RightHandTouchProxyPrefab;
+#pragma warning restore 649
 
         bool m_IsOculus;
 

--- a/Scripts/Proxies/ViveProxyHelper.cs
+++ b/Scripts/Proxies/ViveProxyHelper.cs
@@ -5,6 +5,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 {
     class ViveProxyHelper : MonoBehaviour
     {
+#pragma warning disable 649
         [Serializable]
         public class AffordanceTooltipPlacementOverride
         {
@@ -20,6 +21,7 @@ namespace UnityEditor.Experimental.EditorVR.Proxies
 
         [SerializeField]
         AffordanceTooltipPlacementOverride[] m_LeftPlacementOverrides;
+#pragma warning restore 649
 
         /// <summary>
         /// Tooltip placement arrays to be replaced on the right hand controller

--- a/Scripts/Runtime/SerializedObject.cs
+++ b/Scripts/Runtime/SerializedObject.cs
@@ -5,7 +5,7 @@ namespace UnityEditor.Experimental.EditorVR
 {
     public class SerializedObject
     {
-        public GameObject targetObject;
+        public Object targetObject;
     }
 }
 #endif

--- a/Scripts/UI/CuboidLayout.cs
+++ b/Scripts/UI/CuboidLayout.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEditor.Experimental.EditorVR.Extensions;
+using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEditor.Experimental.EditorVR.Utilities;
 
 namespace UnityEditor.Experimental.EditorVR.UI
 {
@@ -11,6 +11,7 @@ namespace UnityEditor.Experimental.EditorVR.UI
         const float k_LayerHeight = 0.004f;
         const float k_ExtraSpace = 0.00055f; // To avoid Z-fighting
 
+#pragma warning disable 649
         [SerializeField]
         RectTransform[] m_TargetTransforms;
 
@@ -23,6 +24,7 @@ namespace UnityEditor.Experimental.EditorVR.UI
 
         [SerializeField]
         GameObject m_HighlightCubePrefab;
+#pragma warning restore 649
 
         Transform[] m_CubeTransforms;
         Transform[] m_HighlightCubeTransforms;

--- a/Scripts/UI/DefaultToggleGroup.cs
+++ b/Scripts/UI/DefaultToggleGroup.cs
@@ -5,8 +5,10 @@ namespace UnityEditor.Experimental.EditorVR.UI
 {
     sealed class DefaultToggleGroup : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         Toggle m_DefaultToggle;
+#pragma warning restore 649
 
         public Toggle defaultToggle { get { return m_DefaultToggle; } }
     }

--- a/Scripts/UI/GradientButton.cs
+++ b/Scripts/UI/GradientButton.cs
@@ -22,122 +22,9 @@ namespace UnityEditor.Experimental.EditorVR.UI
         const string k_MaterialColorTopProperty = "_ColorTop";
         const string k_MaterialColorBottomProperty = "_ColorBottom";
 
-        public event Action click;
-        public event Action hoverEnter;
-        public event Action hoverExit;
-
-        public Sprite iconSprite
-        {
-            set
-            {
-                m_IconSprite = value;
-                m_Icon.sprite = m_IconSprite;
-            }
-        }
-
-        Sprite m_IconSprite;
-
-        public bool pressed
-        {
-            get { return m_Pressed; }
-            set
-            {
-                if (value != m_Pressed && value) // proceed only if value is true after previously being false
-                {
-                    m_Pressed = value;
-
-                    this.StopCoroutine(ref m_IconHighlightCoroutine);
-
-                    m_IconHighlightCoroutine = StartCoroutine(IconContainerContentsBeginHighlight(true));
-                }
-            }
-        }
-
-        bool m_Pressed;
-
-        public bool highlighted
-        {
-            get { return m_Highlighted; }
-            set
-            {
-                if (m_Highlighted == value)
-                    return;
-
-                // Stop any existing icon highlight coroutines
-                this.StopCoroutine(ref m_IconHighlightCoroutine);
-
-                m_Highlighted = value;
-
-                // Stop any existing begin/end highlight coroutine
-                this.StopCoroutine(ref m_HighlightCoroutine);
-
-                if (!gameObject.activeInHierarchy)
-                    return;
-
-                if (m_Highlighted)
-                    this.RestartCoroutine(ref m_HighlightCoroutine, BeginHighlight());
-                else
-                    this.RestartCoroutine(ref m_HighlightCoroutine, EndHighlight());
-            }
-        }
-
-        bool m_Highlighted;
-
-        public bool alternateIconVisible
-        {
-            set
-            {
-                if (m_AlternateIconSprite) // Only allow sprite swapping if an alternate sprite exists
-                    m_Icon.sprite = value ? m_AlternateIconSprite : m_OriginalIconSprite; // If true, set the icon sprite back to the original sprite
-            }
-            get { return m_Icon.sprite == m_AlternateIconSprite; }
-        }
-
-        public bool visible
-        {
-            get { return m_Visible; }
-            set
-            {
-                if (m_Visible == value)
-                    return;
-
-                m_Visible = value;
-
-                if (m_Visible && !gameObject.activeSelf)
-                    gameObject.SetActive(true);
-
-                this.StopCoroutine(ref m_VisibilityCoroutine);
-                m_VisibilityCoroutine = value ? StartCoroutine(AnimateShow()) : StartCoroutine(AnimateHide());
-            }
-        }
-
-        bool m_Visible;
-
-        public float containerContentsAnimationSpeedMultiplier { set { m_ContainerContentsAnimationSpeedMultiplier = value; } }
-
-        public float iconHighlightedLocalZOffset
-        {
-            set
-            {
-                m_IconHighlightedLocalZOffset = value;
-                m_IconHighlightedLocalPosition = m_OriginalIconLocalPosition + Vector3.forward * m_IconHighlightedLocalZOffset;
-            }
-        }
-
-        public GradientPair normalGradientPair
-        {
-            get { return m_NormalGradientPair; }
-            set { m_NormalGradientPair = value; }
-        }
-
+#pragma warning disable 649
         [SerializeField]
         GradientPair m_NormalGradientPair;
-
-        public GradientPair highlightGradientPair
-        {
-            get { return m_HighlightGradientPair; }
-            set { m_HighlightGradientPair = value; }
-        }
 
         [SerializeField]
         GradientPair m_HighlightGradientPair;
@@ -209,6 +96,13 @@ namespace UnityEditor.Experimental.EditorVR.UI
 
         [SerializeField]
         float m_ContainerContentsAnimationSpeedMultiplier = 1f;
+#pragma warning restore 649
+
+        Sprite m_IconSprite;
+
+        bool m_Pressed;
+        bool m_Highlighted;
+        bool m_Visible;
 
         Material m_ButtonMaterial;
         Vector3 m_OriginalIconLocalPosition;
@@ -222,11 +116,116 @@ namespace UnityEditor.Experimental.EditorVR.UI
         // The initial button reveal coroutines, before highlighting occurs
         Coroutine m_VisibilityCoroutine;
         Coroutine m_ContentVisibilityCoroutine;
-        Coroutine m_HighlighCoroutine;
 
         // The visibility & highlight coroutines
         Coroutine m_HighlightCoroutine;
         Coroutine m_IconHighlightCoroutine;
+
+        public event Action click;
+        public event Action hoverEnter;
+        public event Action hoverExit;
+
+        public Sprite iconSprite
+        {
+            set
+            {
+                m_IconSprite = value;
+                m_Icon.sprite = m_IconSprite;
+            }
+        }
+
+        public bool pressed
+        {
+            get { return m_Pressed; }
+            set
+            {
+                if (value != m_Pressed && value) // proceed only if value is true after previously being false
+                {
+                    m_Pressed = value;
+
+                    this.StopCoroutine(ref m_IconHighlightCoroutine);
+
+                    m_IconHighlightCoroutine = StartCoroutine(IconContainerContentsBeginHighlight(true));
+                }
+            }
+        }
+
+        public bool highlighted
+        {
+            get { return m_Highlighted; }
+            set
+            {
+                if (m_Highlighted == value)
+                    return;
+
+                // Stop any existing icon highlight coroutines
+                this.StopCoroutine(ref m_IconHighlightCoroutine);
+
+                m_Highlighted = value;
+
+                // Stop any existing begin/end highlight coroutine
+                this.StopCoroutine(ref m_HighlightCoroutine);
+
+                if (!gameObject.activeInHierarchy)
+                    return;
+
+                if (m_Highlighted)
+                    this.RestartCoroutine(ref m_HighlightCoroutine, BeginHighlight());
+                else
+                    this.RestartCoroutine(ref m_HighlightCoroutine, EndHighlight());
+            }
+        }
+
+        public bool alternateIconVisible
+        {
+            set
+            {
+                if (m_AlternateIconSprite) // Only allow sprite swapping if an alternate sprite exists
+                    m_Icon.sprite = value ? m_AlternateIconSprite : m_OriginalIconSprite; // If true, set the icon sprite back to the original sprite
+            }
+            get { return m_Icon.sprite == m_AlternateIconSprite; }
+        }
+
+        public bool visible
+        {
+            get { return m_Visible; }
+            set
+            {
+                if (m_Visible == value)
+                    return;
+
+                m_Visible = value;
+
+                if (m_Visible && !gameObject.activeSelf)
+                    gameObject.SetActive(true);
+
+                this.StopCoroutine(ref m_VisibilityCoroutine);
+                m_VisibilityCoroutine = value ? StartCoroutine(AnimateShow()) : StartCoroutine(AnimateHide());
+            }
+        }
+
+        public float containerContentsAnimationSpeedMultiplier { set { m_ContainerContentsAnimationSpeedMultiplier = value; } }
+
+        public float iconHighlightedLocalZOffset
+        {
+            set
+            {
+                m_IconHighlightedLocalZOffset = value;
+                m_IconHighlightedLocalPosition = m_OriginalIconLocalPosition + Vector3.forward * m_IconHighlightedLocalZOffset;
+            }
+        }
+
+        public GradientPair normalGradientPair
+        {
+            get { return m_NormalGradientPair; }
+            set { m_NormalGradientPair = value; }
+        }
+
+        public GradientPair highlightGradientPair
+        {
+            get { return m_HighlightGradientPair; }
+            set { m_HighlightGradientPair = value; }
+        }
 
         public bool interactable
         {

--- a/Scripts/UI/GridCellSizeAdjuster.cs
+++ b/Scripts/UI/GridCellSizeAdjuster.cs
@@ -5,13 +5,15 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
 {
     sealed class GridCellSizeAdjuster : MonoBehaviour
     {
-        RectTransform m_LayoutGroupTransform;
-
+#pragma warning disable 649
         [SerializeField]
         GridLayoutGroup m_LayoutGroup;
 
         [SerializeField]
         float m_XScalePadding = 0.01f;
+#pragma warning restore 649
+
+        RectTransform m_LayoutGroupTransform;
 
         void Awake()
         {

--- a/Scripts/UI/InputField.cs
+++ b/Scripts/UI/InputField.cs
@@ -1,7 +1,3 @@
-#if !UNITY_2017_2_OR_NEWER
-#pragma warning disable 649 // "never assigned to" warning
-#endif
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/Scripts/UI/InputField.cs
+++ b/Scripts/UI/InputField.cs
@@ -31,6 +31,7 @@ namespace UnityEditor.Experimental.EditorVR.UI
 
         const float k_MoveKeyboardTime = 0.2f;
 
+#pragma warning disable 649
         [SerializeField]
         [FlagsProperty]
         SelectionFlags m_SelectionFlags = SelectionFlags.Ray | SelectionFlags.Direct;
@@ -47,6 +48,7 @@ namespace UnityEditor.Experimental.EditorVR.UI
         [HideInInspector]
         [SerializeField] // Serialized so that this remains set after cloning
         protected string m_Text = string.Empty;
+#pragma warning restore 649
 
         bool m_KeyboardOpen;
 

--- a/Scripts/UI/KeyboardMallet.cs
+++ b/Scripts/UI/KeyboardMallet.cs
@@ -6,25 +6,27 @@ namespace UnityEditor.Experimental.EditorVR.UI
 {
     sealed class KeyboardMallet : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
-        private Transform m_StemOrigin;
+        Transform m_StemOrigin;
 
         [SerializeField]
-        private float m_StemLength = 0.06f;
+        float m_StemLength = 0.06f;
 
         [SerializeField]
-        private float m_StemWidth = 0.003125f;
+        float m_StemWidth = 0.003125f;
 
         [SerializeField]
-        private Transform m_Bulb;
+        Transform m_Bulb;
 
         [SerializeField]
-        private float m_BulbRadius;
+        float m_BulbRadius;
 
         [SerializeField]
-        private Collider m_BulbCollider;
+        Collider m_BulbCollider;
+#pragma warning restore 649
 
-        private KeyboardButton m_CurrentButton;
+        KeyboardButton m_CurrentButton;
 
         Coroutine m_ShowHideCoroutine;
 
@@ -96,7 +98,7 @@ namespace UnityEditor.Experimental.EditorVR.UI
             }
         }
 
-        private IEnumerator HideMallet()
+        IEnumerator HideMallet()
         {
             m_Open = false;
 
@@ -125,7 +127,7 @@ namespace UnityEditor.Experimental.EditorVR.UI
             m_ShowHideCoroutine = null;
         }
 
-        private IEnumerator ShowMallet()
+        IEnumerator ShowMallet()
         {
             var stemScale = m_StemOrigin.localScale;
             var currentLength = m_StemOrigin.localScale.y;

--- a/Scripts/UI/KeyboardUI.cs
+++ b/Scripts/UI/KeyboardUI.cs
@@ -19,6 +19,7 @@ namespace UnityEditor.Experimental.EditorVR.UI
         const float k_HorizontalThreshold = 0.7f;
         static Color s_HandleDragColor = UnityBrandColorScheme.green;
 
+#pragma warning disable 649
         [SerializeField]
         List<KeyboardButton> m_Buttons = new List<KeyboardButton>();
 
@@ -33,6 +34,7 @@ namespace UnityEditor.Experimental.EditorVR.UI
 
         [SerializeField]
         SmoothMotion m_SmoothMotion;
+#pragma warning restore 649
 
         bool m_EligibleForDrag;
         bool m_CurrentlyHorizontal;

--- a/Scripts/UI/SubmenuFace.cs
+++ b/Scripts/UI/SubmenuFace.cs
@@ -2,12 +2,12 @@ using System;
 using UnityEditor.Experimental.EditorVR.Core;
 using UnityEditor.Experimental.EditorVR.Helpers;
 using UnityEngine;
-using UnityEngine.Events;
 
 namespace UnityEditor.Experimental.EditorVR.Menus
 {
     class SubmenuFace : MonoBehaviour, IControlHaptics, IRayToNode
     {
+#pragma warning disable 649
         [SerializeField]
         MainMenuButton m_BackButton;
 
@@ -16,6 +16,7 @@ namespace UnityEditor.Experimental.EditorVR.Menus
 
         [SerializeField]
         HapticPulse m_ButtonHoverPulse;
+#pragma warning restore 649
 
         public GradientPair gradientPair { get; set; }
 

--- a/Scripts/UI/UITransformCopy.cs
+++ b/Scripts/UI/UITransformCopy.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
 
         Transform m_TargetTransform;
 
+#pragma warning disable 649
         [SerializeField]
         RectTransform m_SourceRectTransform;
 
@@ -16,7 +17,7 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
         float m_XPositionPadding = 0.005f;
 
         [SerializeField]
-        float m_YPositionPadding = 0f;
+        float m_YPositionPadding;
 
         [SerializeField]
         float m_ZPositionPadding = 0.00055f;
@@ -25,10 +26,11 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
         float m_XScalePadding = 0.01f;
 
         [SerializeField]
-        float m_YScalePadding = 0f;
+        float m_YScalePadding;
 
         [SerializeField]
         bool m_ParentUnderSource = true;
+#pragma warning restore 649
 
         void Awake()
         {

--- a/Scripts/Utilities/ObjectUtils.cs
+++ b/Scripts/Utilities/ObjectUtils.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using UnityEditor.Experimental.EditorVR.Core;
+using UnityEditor.Experimental.EditorVR.Helpers;
 using UnityEngine;
 using UnityObject = UnityEngine.Object;
 
@@ -342,7 +342,7 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
                 }
                 else
                 {
-                    VRView.StartCoroutine(DestroyInSeconds(o, t));
+                    EditorMonoBehaviour.StartEditorCoroutine(DestroyInSeconds(o, t));
                 }
             }
 #endif

--- a/Scripts/Utilities/TransformCopy.cs
+++ b/Scripts/Utilities/TransformCopy.cs
@@ -10,17 +10,18 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
             Local
         }
 
+#pragma warning disable 649
         [SerializeField]
         Transform m_SourceTransform;
 
         [SerializeField]
-        float m_XPositionPadding = 0f;
+        float m_XPositionPadding;
 
         [SerializeField]
-        float m_YPositionPadding = 0f;
+        float m_YPositionPadding;
 
         [SerializeField]
-        float m_ZPositionPadding = 0f;
+        float m_ZPositionPadding;
 
         [SerializeField]
         bool m_ParentUnderSource = true;
@@ -29,7 +30,8 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
         Space m_Space;
 
         [SerializeField]
-        bool m_ForceAlwaysUpdate = false;
+        bool m_ForceAlwaysUpdate;
+#pragma warning restore 649
 
         Vector3 m_Padding;
 

--- a/Tests/Editor/CompilationTest.cs
+++ b/Tests/Editor/CompilationTest.cs
@@ -41,6 +41,10 @@ namespace UnityEditor.Experimental.EditorVR.Tests
             var references = new List<string>();
             ObjectUtils.ForEachAssembly(assembly =>
             {
+#if NET_4_6
+                if (assembly.IsDynamic)
+                    return;
+#endif
                 // Ignore project assemblies because they will cause conflicts
                 if (assembly.FullName.StartsWith("Assembly-CSharp", StringComparison.OrdinalIgnoreCase))
                     return;

--- a/Tests/Editor/Unit/Core/EditingContextManagerTests.cs
+++ b/Tests/Editor/Unit/Core/EditingContextManagerTests.cs
@@ -1,11 +1,11 @@
-﻿using System.IO;
-using UnityEngine;
+﻿using NUnit.Framework;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
-using NUnit.Framework;
 using UnityEditor.Experimental.EditorVR.Core;
-using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEditor.Experimental.EditorVR.Tools;
+using UnityEditor.Experimental.EditorVR.Utilities;
+using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Tests.Core
 {
@@ -97,8 +97,8 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Core
         [Test]
         public void LoadProjectSettings_IfAssetNotFound()
         {
-            if (File.Exists(EditingContextManager.k_SettingsPath))
-                File.Delete(EditingContextManager.k_SettingsPath);
+            if (File.Exists(EditingContextManager.settingsPath))
+                File.Delete(EditingContextManager.settingsPath);
 
             var loaded = EditingContextManager.LoadProjectSettings();
             Assert.IsInstanceOf<EditingContextManagerSettings>(loaded);
@@ -126,8 +126,8 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Core
         [Test]
         public void LoadUserSettings_ProjectSettingsFallback()
         {
-            if (File.Exists(EditingContextManager.k_UserSettingsPath))
-                File.Delete(EditingContextManager.k_UserSettingsPath);
+            if (File.Exists(EditingContextManager.userSettingsPath))
+                File.Delete(EditingContextManager.userSettingsPath);
 
             var projectSettings = EditingContextManager.LoadProjectSettings();
             var userSettings = EditingContextManager.LoadUserSettings();
@@ -138,7 +138,7 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Core
         [Test]
         public void SaveProjectSettings_UpdatesProjectSettingsFile()
         {
-            var path = EditingContextManager.k_SettingsPath;
+            var path = EditingContextManager.settingsPath;
             var lastModTime = File.GetLastWriteTime(path);
             Thread.Sleep(1000); // Wait one second to make sure modified time is later
             EditingContextManager.SaveProjectSettings(settings);
@@ -150,7 +150,7 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Core
         [Test]
         public void SaveUserSettings_UpdatesUserSettingsFile()
         {
-            var path = EditingContextManager.k_UserSettingsPath;
+            var path = EditingContextManager.userSettingsPath;
             var lastModTime = File.GetLastWriteTime(path);
             EditingContextManager.SaveUserSettings(newSettings);
 

--- a/Tools/AnnotationTool/AnnotationTool.cs
+++ b/Tools/AnnotationTool/AnnotationTool.cs
@@ -88,6 +88,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
         public delegate void AnnotationFinishedCallback(MeshFilter meshFilter);
         public static AnnotationFinishedCallback AnnotationFinished;
 
+#pragma warning disable 649
         [SerializeField]
         ActionMap m_ActionMap;
 
@@ -102,6 +103,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
         [SerializeField]
         AnnotationContextMenu m_MenuPrefab;
+#pragma warning restore 649
 
         Action<float> m_BrushSizeChanged;
 

--- a/Tools/AnnotationTool/UserInterface/AnnotationContextMenu.cs
+++ b/Tools/AnnotationTool/UserInterface/AnnotationContextMenu.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 {
     sealed class AnnotationContextMenu : MonoBehaviour, IMenu
     {
+#pragma warning disable 649
         [SerializeField]
         Button m_CloseButton;
 
@@ -31,6 +32,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
         [SerializeField]
         Slider m_ColorSlider;
+#pragma warning restore 649
 
         AnnotationTool.Preferences m_Preferences;
         bool m_InsideUIUpdate;

--- a/Tools/AnnotationTool/UserInterface/AnnotationPointer.cs
+++ b/Tools/AnnotationTool/UserInterface/AnnotationPointer.cs
@@ -9,8 +9,10 @@ namespace UnityEditor.Experimental.EditorVR.Tools
         const float k_BottomRadius = 0.01f;
         const float k_YScale = 2.5f;
 
+#pragma warning disable 649
         [SerializeField]
         Material m_ConeMaterial;
+#pragma warning restore 649
 
         Material m_ConeMaterialInstance;
 

--- a/Tools/AnnotationTool/UserInterface/BrushSizeUI.cs
+++ b/Tools/AnnotationTool/UserInterface/BrushSizeUI.cs
@@ -12,11 +12,13 @@ namespace UnityEditor.Experimental.EditorVR.Tools
         const float k_MinSize = 0.625f;
         const float k_MaxSize = 12.5f;
 
+#pragma warning disable 649
         [SerializeField]
         RectTransform m_SliderHandle;
 
         [SerializeField]
         Slider m_Slider;
+#pragma warning restore 649
 
         Image m_SliderHandleImage;
         MenuHideFlags m_MenuHideFlags;

--- a/Tools/AnnotationTool/UserInterface/ColorPickerActivator.cs
+++ b/Tools/AnnotationTool/UserInterface/ColorPickerActivator.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 {
     public class ColorPickerActivator : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, IPointerExitHandler
     {
+#pragma warning disable 649
         [SerializeField]
         Transform m_TargetScale;
 
@@ -16,6 +17,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
         [SerializeField]
         float m_PickerOffset = 0.045f;
+#pragma warning restore 649
 
         Coroutine m_HighlightCoroutine;
 

--- a/Tools/AnnotationTool/UserInterface/ColorPickerUI.cs
+++ b/Tools/AnnotationTool/UserInterface/ColorPickerUI.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 {
     public class ColorPickerUI : MonoBehaviour, IPointerExitHandler
     {
+#pragma warning disable 649
         [SerializeField]
         float m_FadeTime;
 
@@ -29,6 +30,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
         [SerializeField]
         Slider m_BrightnessSlider;
+#pragma warning restore 649
 
         Vector3 m_PickerTargetPosition;
 

--- a/Tools/CreatePrimitiveTool/CreatePrimitiveMenu.cs
+++ b/Tools/CreatePrimitiveTool/CreatePrimitiveMenu.cs
@@ -12,6 +12,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
         const string k_BottomGradientProperty = "_ColorBottom";
         const string k_TopGradientProperty = "_ColorTop";
 
+#pragma warning disable 649
         [SerializeField]
         Renderer m_TitleIcon;
 
@@ -23,6 +24,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
         [SerializeField]
         HapticPulse m_ButtonHoverPulse;
+#pragma warning restore 649
 
         Material m_TitleIconMaterial;
 
@@ -54,7 +56,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
             }
         }
 
-        private void OnDestroy()
+        void OnDestroy()
         {
             foreach (var button in m_Buttons)
             {

--- a/Tools/CreatePrimitiveTool/CreatePrimitiveMenuButtonUI.cs
+++ b/Tools/CreatePrimitiveTool/CreatePrimitiveMenuButtonUI.cs
@@ -4,11 +4,13 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 {
     public sealed class CreatePrimitiveMenuButtonUI : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         Transform m_ShapeTransform;
 
         [SerializeField]
         RectTransform m_BackgroundGradientTransform;
+#pragma warning restore 649
 
         Vector3 m_OriginalShapeLocalScale;
         Vector2 m_OriginalBackgroundSizeDelta;

--- a/Tools/CreatePrimitiveTool/CreatePrimitiveTool.cs
+++ b/Tools/CreatePrimitiveTool/CreatePrimitiveTool.cs
@@ -11,11 +11,13 @@ namespace UnityEditor.Experimental.EditorVR.Tools
         IUsesRayOrigin, IUsesSpatialHash, IUsesViewerScale, ISelectTool, IIsHoveringOverUI, IIsMainMenuVisible,
         IRayVisibilitySettings, IMenuIcon, IRequestFeedback, IUsesNode
     {
+#pragma warning disable 649
         [SerializeField]
         CreatePrimitiveMenu m_MenuPrefab;
 
         [SerializeField]
         Sprite m_Icon;
+#pragma warning restore 649
 
         const float k_DrawDistance = 0.075f;
 

--- a/Tools/LocomotionTool/LocomotionTool.cs
+++ b/Tools/LocomotionTool/LocomotionTool.cs
@@ -15,6 +15,19 @@ namespace UnityEditor.Experimental.EditorVR.Tools
         ICustomActionMap, ILinkedObject, IUsesViewerScale, ISettingsMenuItemProvider, ISerializePreferences,
         IUsesDeviceType, IGetVRPlayerObjects, IBlockUIInteraction, IRequestFeedback, IUsesNode
     {
+        [Serializable]
+        class Preferences
+        {
+            [SerializeField]
+            bool m_BlinkMode;
+
+            public bool blinkMode
+            {
+                get { return m_BlinkMode; }
+                set { m_BlinkMode = value; }
+            }
+        }
+
         const float k_FastMoveSpeed = 20f;
         const float k_SlowMoveSpeed = 1f;
         const float k_RotationDamping = 0.2f;
@@ -39,6 +52,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
         static readonly Vector3 k_RingOffset = new Vector3(0f, -0.3f, 0.5f);
 
+#pragma warning disable 649
         [SerializeField]
         GameObject m_BlinkVisualsPrefab;
 
@@ -53,19 +67,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
         [SerializeField]
         GameObject m_RingPrefab;
-
-        [Serializable]
-        class Preferences
-        {
-            [SerializeField]
-            bool m_BlinkMode;
-
-            public bool blinkMode
-            {
-                get { return m_BlinkMode; }
-                set { m_BlinkMode = value; }
-            }
-        }
+#pragma warning restore 649
 
         Preferences m_Preferences;
 

--- a/Tools/LocomotionTool/Scripts/BlinkVisuals.cs
+++ b/Tools/LocomotionTool/Scripts/BlinkVisuals.cs
@@ -9,6 +9,7 @@ public class BlinkVisuals : MonoBehaviour, IUsesViewerScale, IRaycast
 {
     const float k_Epsilon = 0.001f;
 
+#pragma warning disable 649
     [SerializeField]
     float m_LineWidth = 1f;
 
@@ -47,6 +48,7 @@ public class BlinkVisuals : MonoBehaviour, IUsesViewerScale, IRaycast
 
     [SerializeField]
     GameObject m_ArcLocator;
+#pragma warning restore 649
 
     float m_SpherePosition;
     VRLineRenderer m_LineRenderer;

--- a/Tools/LocomotionTool/Scripts/Ring.cs
+++ b/Tools/LocomotionTool/Scripts/Ring.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 public class Ring : MonoBehaviour
 {
+#pragma warning disable 649
     [SerializeField]
     Transform m_RingTransform;
 
@@ -40,6 +41,7 @@ public class Ring : MonoBehaviour
 
     [SerializeField]
     LineRenderer m_LineB;
+#pragma warning restore 649
 
     readonly Gradient m_OrigGradient = new Gradient();
     readonly Gradient m_CurrentGradient = new Gradient();

--- a/Tools/LocomotionTool/Scripts/ViewerScaleVisuals.cs
+++ b/Tools/LocomotionTool/Scripts/ViewerScaleVisuals.cs
@@ -13,6 +13,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 {
     sealed class ViewerScaleVisuals : MonoBehaviour, IUsesViewerScale
     {
+#pragma warning disable 649
         [SerializeField]
         float m_IconTranslateCoefficient = -0.16f;
 
@@ -35,6 +36,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
         [SerializeField]
         GameObject m_IconPrefab;
+#pragma warning restore 649
 
         float m_LineWidth;
 

--- a/Tools/SelectionTool/SelectionTool.cs
+++ b/Tools/SelectionTool/SelectionTool.cs
@@ -39,6 +39,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
         const float k_BLockSelectDragThreshold = 0.01f;
         static readonly Quaternion k_TooltipRotation = Quaternion.AngleAxis(90, Vector3.right);
 
+#pragma warning disable 649
         [SerializeField]
         Sprite m_Icon;
 
@@ -53,6 +54,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
         [SerializeField]
         GameObject m_SettingsMenuItemPrefab;
+#pragma warning restore 649
 
         Preferences m_Preferences;
 

--- a/Tools/TransformTool/TransformTool.cs
+++ b/Tools/TransformTool/TransformTool.cs
@@ -158,28 +158,7 @@ namespace UnityEditor.Experimental.EditorVR.Tools
             }
         }
 
-        public List<IAction> actions
-        {
-            get
-            {
-                if (!this.IsSharedUpdater(this))
-                    return null;
-
-                if (m_Actions == null)
-                {
-                    m_Actions = new List<IAction>
-                    {
-                        m_PivotModeToggleAction,
-                        m_PivotRotationToggleAction,
-                        m_ManipulatorToggleAction
-                    };
-                }
-                return m_Actions;
-            }
-        }
-
-        List<IAction> m_Actions;
-
+#pragma warning disable 649
         [SerializeField]
         Sprite m_OriginCenterIcon;
 
@@ -212,6 +191,9 @@ namespace UnityEditor.Experimental.EditorVR.Tools
 
         [SerializeField]
         HapticPulse m_RotatePulse;
+#pragma warning restore 649
+
+        List<IAction> m_Actions;
 
         BaseManipulator m_CurrentManipulator;
 
@@ -253,6 +235,26 @@ namespace UnityEditor.Experimental.EditorVR.Tools
         public event Action<Transform, HashSet<Transform>> objectsGrabbed;
         public event Action<Transform, Transform[]> objectsDropped;
         public event Action<Transform, Transform> objectsTransferred;
+
+        public List<IAction> actions
+        {
+            get
+            {
+                if (!this.IsSharedUpdater(this))
+                    return null;
+
+                if (m_Actions == null)
+                {
+                    m_Actions = new List<IAction>
+                    {
+                        m_PivotModeToggleAction,
+                        m_PivotRotationToggleAction,
+                        m_ManipulatorToggleAction
+                    };
+                }
+                return m_Actions;
+            }
+        }
 
         public bool manipulatorVisible { private get; set; }
 

--- a/Tools/VacuumTool/VacuumTool.cs
+++ b/Tools/VacuumTool/VacuumTool.cs
@@ -10,8 +10,10 @@ namespace UnityEditor.Experimental.EditorVR.Tools
     sealed class VacuumTool : MonoBehaviour, ITool, ICustomActionMap, IUsesRayOrigin, IUsesViewerScale,
         IRequestFeedback, IUsesNode
     {
+#pragma warning disable 649
         [SerializeField]
         ActionMap m_ActionMap;
+#pragma warning restore 649
 
         float m_LastClickTime;
         readonly Dictionary<Transform, Coroutine> m_VacuumingCoroutines = new Dictionary<Transform, Coroutine>();

--- a/Workspaces/Base/Workspace.cs
+++ b/Workspaces/Base/Workspace.cs
@@ -12,14 +12,15 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         IUsesViewerScale, IControlHaptics, IRayToNode
     {
         const float k_MaxFrameSize = 100f; // Because BlendShapes cap at 100, our workspace maxes out at 100m wide
+        protected const float k_DoubleFaceMargin = FaceMargin * 2;
 
         public static readonly Vector3 DefaultBounds = new Vector3(0.7f, 0f, 0.4f);
         public static readonly Vector3 MinBounds = new Vector3(0.677f, 0f, 0.1f);
 
         public const float FaceMargin = 0.025f;
-        protected float DoubleFaceMargin = FaceMargin * 2;
         public const float HighlightMargin = 0.002f;
 
+#pragma warning disable 649
         [SerializeField]
         Vector3 m_MinBounds = MinBounds;
 
@@ -40,6 +41,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         protected HapticPulse m_MovePulse;
+#pragma warning restore 649
 
         Bounds m_ContentBounds;
         BoxCollider m_OuterCollider;

--- a/Workspaces/Base/WorkspaceUI.cs
+++ b/Workspaces/Base/WorkspaceUI.cs
@@ -138,6 +138,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         static readonly Vector3 k_BaseFrontPanelRotation = Vector3.zero;
         static readonly Vector3 k_MaxFrontPanelRotation = new Vector3(90f, 0f, 0f);
 
+#pragma warning disable 649
         [SerializeField]
         Transform m_SceneContainer;
 
@@ -245,6 +246,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         WorkspaceButton m_ResizeButton;
+#pragma warning restore 649
 
         BoxCollider m_FrameCollider;
         Bounds m_Bounds;

--- a/Workspaces/Common/Scripts/EditorWindowWorkspace.cs
+++ b/Workspaces/Common/Scripts/EditorWindowWorkspace.cs
@@ -7,8 +7,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     abstract class EditorWindowWorkspace : Workspace
     {
+#pragma warning disable 649
         [SerializeField]
         GameObject m_CaptureWindowPrefab;
+#pragma warning restore 649
 
         Transform m_CaptureWindow;
 

--- a/Workspaces/Common/Scripts/FilterButtonUI.cs
+++ b/Workspaces/Common/Scripts/FilterButtonUI.cs
@@ -16,11 +16,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         const float k_HoverAlpha = 1;
         const float k_NormalAlpha = 0.95f;
 
-        public Button button
-        {
-            get { return m_Button; }
-        }
-
+#pragma warning disable 649
         [SerializeField]
         Button m_Button;
 
@@ -40,8 +36,14 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         [SerializeField]
         Text m_Text;
 #endif
+#pragma warning restore 649
 
         Transform m_InteractingRayOrigin;
+
+        public Button button
+        {
+            get { return m_Button; }
+        }
 
 #if INCLUDE_TEXT_MESH_PRO
         public TextMeshProUGUI text { get { return m_Text; } }

--- a/Workspaces/Common/Scripts/FilterUI.cs
+++ b/Workspaces/Common/Scripts/FilterUI.cs
@@ -17,6 +17,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         const string k_AllText = "All";
         const string k_MaterialStencilRefProperty = "_StencilRef";
 
+#pragma warning disable 649
 #if INCLUDE_TEXT_MESH_PRO
         [SerializeField]
         TextMeshProUGUI m_SummaryText;
@@ -60,11 +61,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         WorkspaceButton m_SummaryButton;
-
-        public string searchQuery
-        {
-            get { return m_SearchQuery; }
-        }
+#pragma warning restore 649
 
         string m_SearchQuery = string.Empty;
 
@@ -76,6 +73,11 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         float m_HiddenButtonListYSpacing;
         List<string> m_FilterTypes;
         Material m_BackgroundMaterial;
+
+        public string searchQuery
+        {
+            get { return m_SearchQuery; }
+        }
 
         public List<string> filterList
         {

--- a/Workspaces/Common/Scripts/WorkspaceButton.cs
+++ b/Workspaces/Common/Scripts/WorkspaceButton.cs
@@ -16,97 +16,16 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         const string k_MaterialColorTopProperty = "_ColorTop";
         const string k_MaterialColorBottomProperty = "_ColorBottom";
 
-        public event Action<Transform> clicked;
-        public event Action<Transform> hovered;
-
-        public bool autoHighlight
-        {
-            get { return m_AutoHighlight; }
-            set { m_AutoHighlight = value; }
-        }
-
+#pragma warning disable 649
         [SerializeField]
         bool m_AutoHighlight = true;
-
-        public Sprite iconSprite
-        {
-            set
-            {
-                m_IconSprite = value;
-                m_Icon.sprite = m_IconSprite;
-            }
-        }
-
-        Sprite m_IconSprite;
-
-        public Color customHighlightColor
-        {
-            get { return m_CustomHighlightColor; }
-            set { m_CustomHighlightColor = value; }
-        }
 
         [Header("Extras")]
         [SerializeField]
         Color m_CustomHighlightColor = UnityBrandColorScheme.light;
 
-        public bool pressed
-        {
-            get { return m_Pressed; }
-            set
-            {
-                if (m_Highlighted && value != m_Pressed && value) // proceed only if value is true after previously being false
-                {
-                    m_Pressed = value;
-
-                    this.StopCoroutine(ref m_IconHighlightCoroutine);
-
-                    m_IconHighlightCoroutine = StartCoroutine(IconContainerContentsBeginHighlight(true));
-                }
-            }
-        }
-
-        bool m_Pressed;
-
-        public bool highlighted
-        {
-            set
-            {
-                if (m_Highlighted == value)
-                    return;
-                else
-                {
-                    // Stop any existing icon highlight coroutines
-                    this.StopCoroutine(ref m_IconHighlightCoroutine);
-
-                    m_Highlighted = value;
-
-                    // Stop any existing begin/end highlight coroutine
-                    this.StopCoroutine(ref m_HighlightCoroutine);
-
-                    if (!gameObject.activeInHierarchy)
-                        return;
-
-                    m_HighlightCoroutine = m_Highlighted ? StartCoroutine(BeginHighlight()) : StartCoroutine(EndHighlight());
-                }
-            }
-        }
-
-        bool m_Highlighted;
-
-        public bool alternateIconVisible
-        {
-            set
-            {
-                if (m_AlternateIconSprite) // Only allow sprite swapping if an alternate sprite exists
-                    m_Icon.sprite = value ? m_AlternateIconSprite : m_OriginalIconSprite; // If true, set the icon sprite back to the original sprite
-            }
-            get { return m_Icon.sprite == m_AlternateIconSprite; }
-        }
-
         [SerializeField]
         Sprite m_AlternateIconSprite;
-
-        public MeshRenderer buttonMeshRenderer { get { return m_ButtonMeshRenderer; } }
 
         [SerializeField]
         MeshRenderer m_ButtonMeshRenderer;
@@ -140,6 +59,12 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         [SerializeField]
         [Range(0f, 2f)]
         float m_DelayBeforeReveal = 0.25f;
+#pragma warning restore 649
+
+        Sprite m_IconSprite;
+
+        bool m_Pressed;
+        bool m_Highlighted;
 
         GradientPair m_OriginalGradientPair;
         GradientPair m_HighlightGradientPair;
@@ -163,6 +88,82 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         // The already visible, highlight coroutines
         Coroutine m_HighlightCoroutine;
         Coroutine m_IconHighlightCoroutine;
+
+        public event Action<Transform> clicked;
+        public event Action<Transform> hovered;
+
+        public bool autoHighlight
+        {
+            get { return m_AutoHighlight; }
+            set { m_AutoHighlight = value; }
+        }
+
+        public Sprite iconSprite
+        {
+            set
+            {
+                m_IconSprite = value;
+                m_Icon.sprite = m_IconSprite;
+            }
+        }
+
+        public Color customHighlightColor
+        {
+            get { return m_CustomHighlightColor; }
+            set { m_CustomHighlightColor = value; }
+        }
+
+        public bool pressed
+        {
+            get { return m_Pressed; }
+            set
+            {
+                if (m_Highlighted && value != m_Pressed && value) // proceed only if value is true after previously being false
+                {
+                    m_Pressed = value;
+
+                    this.StopCoroutine(ref m_IconHighlightCoroutine);
+
+                    m_IconHighlightCoroutine = StartCoroutine(IconContainerContentsBeginHighlight(true));
+                }
+            }
+        }
+
+        public bool highlighted
+        {
+            set
+            {
+                if (m_Highlighted == value)
+                    return;
+                else
+                {
+                    // Stop any existing icon highlight coroutines
+                    this.StopCoroutine(ref m_IconHighlightCoroutine);
+
+                    m_Highlighted = value;
+
+                    // Stop any existing begin/end highlight coroutine
+                    this.StopCoroutine(ref m_HighlightCoroutine);
+
+                    if (!gameObject.activeInHierarchy)
+                        return;
+
+                    m_HighlightCoroutine = m_Highlighted ? StartCoroutine(BeginHighlight()) : StartCoroutine(EndHighlight());
+                }
+            }
+        }
+
+        public bool alternateIconVisible
+        {
+            set
+            {
+                if (m_AlternateIconSprite) // Only allow sprite swapping if an alternate sprite exists
+                    m_Icon.sprite = value ? m_AlternateIconSprite : m_OriginalIconSprite; // If true, set the icon sprite back to the original sprite
+            }
+            get { return m_Icon.sprite == m_AlternateIconSprite; }
+        }
+
+        public MeshRenderer buttonMeshRenderer { get { return m_ButtonMeshRenderer; } }
 
         public Button button { get { return m_Button; } }
 

--- a/Workspaces/Common/Scripts/WorkspaceHighlight.cs
+++ b/Workspaces/Common/Scripts/WorkspaceHighlight.cs
@@ -14,8 +14,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         Coroutine m_HighlightCoroutine;
         Material m_TopHighlightMaterial;
 
+#pragma warning disable 649
         [SerializeField]
         MeshRenderer m_TopHighlightRenderer;
+#pragma warning restore 649
 
         public bool visible
         {

--- a/Workspaces/Common/Scripts/ZoomSliderUI.cs
+++ b/Workspaces/Common/Scripts/ZoomSliderUI.cs
@@ -6,12 +6,14 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class ZoomSliderUI : MonoBehaviour
     {
-        public Slider zoomSlider { get { return m_ZoomSlider; } }
-
+#pragma warning disable 649
         [SerializeField]
         Slider m_ZoomSlider;
+#pragma warning restore 649
 
         public event Action<float> sliding;
+
+        public Slider zoomSlider { get { return m_ZoomSlider; } }
 
         public void ZoomSlider(float value)
         {

--- a/Workspaces/HierarchyWorkspace/HierarchyWorkspace.cs
+++ b/Workspaces/HierarchyWorkspace/HierarchyWorkspace.cs
@@ -14,6 +14,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
     {
         protected const string k_Locked = "Locked";
 
+#pragma warning disable 649
         [SerializeField]
         GameObject m_ContentPrefab;
 
@@ -25,6 +26,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         GameObject m_CreateEmptyPrefab;
+#pragma warning restore 649
 
         HierarchyUI m_HierarchyUI;
         protected FilterUI m_FilterUI;
@@ -151,8 +153,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             var size = contentBounds.size;
             var listView = m_HierarchyUI.listView;
             size.y = float.MaxValue; // Add height for dropdowns
-            size.x -= DoubleFaceMargin; // Shrink the content width, so that there is space allowed to grab and scroll
-            size.z -= DoubleFaceMargin; // Reduce the height of the inspector contents as to fit within the bounds of the workspace
+            size.x -= k_DoubleFaceMargin; // Shrink the content width, so that there is space allowed to grab and scroll
+            size.z -= k_DoubleFaceMargin; // Reduce the height of the inspector contents as to fit within the bounds of the workspace
             listView.size = size;
         }
 

--- a/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
+++ b/Workspaces/HierarchyWorkspace/Scripts/HierarchyListItem.cs
@@ -16,6 +16,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         const float k_ExpandArrowRotateSpeed = 0.4f;
 
+#pragma warning disable 649
         [SerializeField]
         TextMeshProUGUI m_Text;
 
@@ -67,6 +68,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         [Tooltip("The fraction of the cube height to use for stacking grabbed rows")]
         [SerializeField]
         float m_StackingFraction = 0.3f;
+#pragma warning restore 649
 
         Color m_NormalColor;
         Color m_NormalTextColor;
@@ -241,7 +243,11 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             UpdateArrow(expanded);
 
 #if UNITY_EDITOR
+#if UNITY_2018_3_OR_NEWER
+            var isPrefab = gameObject && PrefabUtility.GetPrefabInstanceStatus(gameObject) == PrefabInstanceStatus.Connected;
+#else
             var isPrefab = gameObject && PrefabUtility.GetPrefabType(gameObject) == PrefabType.PrefabInstance;
+#endif
 #else
             var isPrefab = false;
 #endif

--- a/Workspaces/HierarchyWorkspace/Scripts/HierarchyListViewController.cs
+++ b/Workspaces/HierarchyWorkspace/Scripts/HierarchyListViewController.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using ListView;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using ListView;
 using UnityEditor.Experimental.EditorVR.Handles;
 using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEngine;
@@ -12,6 +12,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
     {
         const float k_ClipMargin = 0.001f; // Give the cubes a margin so that their sides don't get clipped
 
+#pragma warning disable 649
         [SerializeField]
         BaseHandle m_TopDropZone;
 
@@ -35,6 +36,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         Material m_SceneIconWhiteMaterial;
+#pragma warning restore 649
 
         Material m_TopDropZoneMaterial;
         Material m_BottomDropZoneMaterial;

--- a/Workspaces/HierarchyWorkspace/Scripts/HierarchyUI.cs
+++ b/Workspaces/HierarchyWorkspace/Scripts/HierarchyUI.cs
@@ -5,11 +5,13 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class HierarchyUI : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         HierarchyListViewController m_ListView;
 
         [SerializeField]
         BaseHandle m_ScrollHandle;
+#pragma warning restore 649
 
         public HierarchyListViewController listView { get { return m_ListView; } }
 

--- a/Workspaces/InspectorWorkspace/InspectorWorkspace.cs
+++ b/Workspaces/InspectorWorkspace/InspectorWorkspace.cs
@@ -12,11 +12,13 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
     {
         public new static readonly Vector3 DefaultBounds = new Vector3(0.3f, 0.1f, 0.5f);
 
+#pragma warning disable 649
         [SerializeField]
         GameObject m_ContentPrefab;
 
         [SerializeField]
         GameObject m_LockPrefab;
+#pragma warning restore 649
 
         InspectorUI m_InspectorUI;
         GameObject m_SelectedObject;
@@ -342,7 +344,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             var listView = m_InspectorUI.listView;
             var bounds = contentBounds;
             size.y = float.MaxValue; // Add height for dropdowns
-            size.x -= DoubleFaceMargin; // Shrink the content width, so that there is space allowed to grab and scroll
+            size.x -= k_DoubleFaceMargin; // Shrink the content width, so that there is space allowed to grab and scroll
             size.z -= FaceMargin; // Reduce the height of the inspector contents as to fit within the bounds of the workspace
             bounds.size = size;
             listView.size = bounds.size;

--- a/Workspaces/InspectorWorkspace/Scripts/InspectorListViewController.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/InspectorListViewController.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿#if UNITY_EDITOR
 using ListView;
+using System;
+using System.Collections.Generic;
 using UnityEditor.Experimental.EditorVR.Data;
 using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEngine;
@@ -215,9 +216,11 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
                 var noClipHighlightMaterials = new[] { m_NoClipHighlightMaterial, m_NoClipHighlightMaskMaterial };
                 item.SetMaterials(m_RowCubeMaterial, m_BackingCubeMaterial, m_UIMaterial, m_UIMaskMaterial, m_NoClipBackingCubeMaterial, highlightMaterials, noClipHighlightMaterials);
 
+#if UNITY_EDITOR
                 var numberItem = item as InspectorNumberItem;
                 if (numberItem)
                     numberItem.arraySizeChanged += OnArraySizeChanged;
+#endif
 
                 item.setup = true;
             }
@@ -309,3 +312,4 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         }
     }
 }
+#endif

--- a/Workspaces/InspectorWorkspace/Scripts/InspectorUI.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/InspectorUI.cs
@@ -5,28 +5,30 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class InspectorUI : MonoBehaviour
     {
-        public InspectorListViewController listView
-        {
-            get { return m_ListView; }
-        }
-
+#pragma warning disable 649
         [SerializeField]
         InspectorListViewController m_ListView;
 
-        public LinearHandle scrollHandle
-        {
-            get { return m_ScrollHandle; }
-        }
-
         [SerializeField]
         LinearHandle m_ScrollHandle;
+
+        [SerializeField]
+        RectTransform m_ListPanel;
+#pragma warning restore 649
 
         public RectTransform listPanel
         {
             get { return m_ListPanel; }
         }
 
-        [SerializeField]
-        RectTransform m_ListPanel;
+        public LinearHandle scrollHandle
+        {
+            get { return m_ScrollHandle; }
+        }
+
+        public InspectorListViewController listView
+        {
+            get { return m_ListView; }
+        }
     }
 }

--- a/Workspaces/InspectorWorkspace/Scripts/InspectorUI.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/InspectorUI.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿#if UNITY_EDITOR
+using UnityEngine;
 using UnityEditor.Experimental.EditorVR.Handles;
 
 namespace UnityEditor.Experimental.EditorVR.Workspaces
@@ -32,3 +33,4 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         }
     }
 }
+#endif

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorArrayHeaderItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorArrayHeaderItem.cs
@@ -9,8 +9,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         static readonly Quaternion k_ExpandedRotation = Quaternion.AngleAxis(90f, Vector3.forward);
         static readonly Quaternion k_NormalRotation = Quaternion.identity;
 
+#pragma warning disable 649
         [SerializeField]
         Button m_ExpandArrow;
+#pragma warning restore 649
 
         public override void UpdateSelf(float width, int depth, bool expanded)
         {

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorBoolItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorBoolItem.cs
@@ -1,13 +1,15 @@
-﻿using UnityEngine;
-using UnityEditor.Experimental.EditorVR.Data;
+﻿using UnityEditor.Experimental.EditorVR.Data;
+using UnityEngine;
 using UnityEngine.UI;
 
 namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class InspectorBoolItem : InspectorPropertyItem
     {
+#pragma warning disable 649
         [SerializeField]
         Toggle m_Toggle;
+#pragma warning restore 649
 
         public override void Setup(InspectorData data)
         {

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorBoundsItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorBoundsItem.cs
@@ -8,11 +8,13 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class InspectorBoundsItem : InspectorPropertyItem
     {
+#pragma warning disable 649
         [SerializeField]
         NumericInputField[] m_CenterFields;
 
         [SerializeField]
         NumericInputField[] m_ExtentsFields;
+#pragma warning restore 649
 
         public override void Setup(InspectorData data)
         {
@@ -95,19 +97,19 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         {
             object dropObject = null;
 #if UNITY_EDITOR
-            var inputfields = fieldBlock.GetComponentsInChildren<NumericInputField>();
+            var inputFields = fieldBlock.GetComponentsInChildren<NumericInputField>();
 
-            if (inputfields.Length > 3) // If we've grabbed all of the fields
+            if (inputFields.Length > 3) // If we've grabbed all of the fields
                 dropObject = m_SerializedProperty.boundsValue;
-            if (inputfields.Length > 1) // If we've grabbed one vector
+            if (inputFields.Length > 1) // If we've grabbed one vector
             {
-                if (m_CenterFields.Intersect(inputfields).Any())
+                if (m_CenterFields.Intersect(inputFields).Any())
                     dropObject = m_SerializedProperty.boundsValue.center;
                 else
                     dropObject = m_SerializedProperty.boundsValue.extents;
             }
-            else if (inputfields.Length > 0) // If we've grabbed a single field
-                dropObject = inputfields[0].text;
+            else if (inputFields.Length > 0) // If we've grabbed a single field
+                dropObject = inputFields[0].text;
 #endif
 
             return dropObject;

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorComponentItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorComponentItem.cs
@@ -13,6 +13,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         static readonly Quaternion k_ExpandedRotation = Quaternion.AngleAxis(90f, Vector3.forward);
         static readonly Quaternion k_NormalRotation = Quaternion.identity;
 
+#pragma warning disable 649
         [SerializeField]
         Button m_ExpandArrow;
 
@@ -24,6 +25,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         TextMeshProUGUI m_NameText;
+#pragma warning restore 649
 
         public override void Setup(InspectorData data)
         {

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorDropDownItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorDropDownItem.cs
@@ -14,8 +14,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         const string k_Nothing = "Nothing";
         const string k_Everything = "Everything";
 
+#pragma warning disable 649
         [SerializeField]
         DropDown m_DropDown;
+#pragma warning restore 649
 
         public override void Setup(InspectorData data)
         {

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorHeaderItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorHeaderItem.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections;
 using System.Linq;
 using UnityEditor.Experimental.EditorVR.Data;
@@ -190,3 +191,4 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         }
     }
 }
+#endif

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorHeaderItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorHeaderItem.cs
@@ -11,6 +11,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class InspectorHeaderItem : InspectorListItem
     {
+#pragma warning disable 649
         [SerializeField]
         RawImage m_Icon;
 
@@ -23,11 +24,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         [SerializeField]
         Toggle m_StaticToggle;
 
-        public Toggle lockToggle
-        {
-            get { return m_LockToggle; }
-        }
-
         [SerializeField]
         Toggle m_LockToggle;
 
@@ -39,6 +35,12 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         MeshRenderer m_Button;
+#pragma warning restore 649
+
+        public Toggle lockToggle
+        {
+            get { return m_LockToggle; }
+        }
 
         GameObject m_TargetGameObject;
 

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorListItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorListItem.cs
@@ -15,10 +15,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         const float k_Indent = 0.02f;
         const float k_HorizThreshold = 0.85f;
 
-        protected CuboidLayout m_CuboidLayout;
-
-        protected InputField[] m_InputFields;
-
+#pragma warning disable 649
         [SerializeField]
         BaseHandle m_Cube;
 
@@ -30,6 +27,11 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         Material m_DropHighlightMaterial;
+#pragma warning restore 649
+
+        protected CuboidLayout m_CuboidLayout;
+
+        protected InputField[] m_InputFields;
 
         ClipText[] m_ClipTexts;
 

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorNumberItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorNumberItem.cs
@@ -17,7 +17,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 #pragma warning restore 649
 
         public SerializedPropertyType propertyType { get; private set; }
+
+#if UNITY_EDITOR
         public event Action<PropertyData> arraySizeChanged;
+#endif
 
         public override void Setup(InspectorData data)
         {

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorNumberItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorNumberItem.cs
@@ -8,11 +8,13 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class InspectorNumberItem : InspectorPropertyItem
     {
+#pragma warning disable 649
         [SerializeField]
         NumericInputField m_InputField;
 
         [SerializeField]
         WorkspaceButton[] m_IncrementDecrementButtons;
+#pragma warning restore 649
 
         public SerializedPropertyType propertyType { get; private set; }
         public event Action<PropertyData> arraySizeChanged;

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorObjectFieldItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorObjectFieldItem.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using TMPro;
 using UnityEditor.Experimental.EditorVR.Data;
 using UnityEditor.Experimental.EditorVR.Utilities;
@@ -115,3 +116,4 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         }
     }
 }
+#endif

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorObjectFieldItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorObjectFieldItem.cs
@@ -9,11 +9,13 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class InspectorObjectFieldItem : InspectorPropertyItem
     {
+#pragma warning disable 649
         [SerializeField]
         TextMeshProUGUI m_FieldLabel;
 
         [SerializeField]
         MeshRenderer m_Button;
+#pragma warning restore 649
 
         Type m_ObjectType;
         string m_ObjectTypeName;

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorPropertyItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorPropertyItem.cs
@@ -7,24 +7,26 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     abstract class InspectorPropertyItem : InspectorListItem
     {
+#pragma warning disable 649
         [SerializeField]
         TextMeshProUGUI m_Label;
+
+        [SerializeField]
+        Transform m_TooltipTarget;
+
+        [SerializeField]
+        Transform m_TooltipSource;
+#pragma warning restore 649
 
         public Transform tooltipTarget
         {
             get { return m_TooltipTarget; }
         }
 
-        [SerializeField]
-        Transform m_TooltipTarget;
-
         public Transform tooltipSource
         {
             get { return m_TooltipSource; }
         }
-
-        [SerializeField]
-        Transform m_TooltipSource;
 
         public TextAlignment tooltipAlignment
         {

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorRectItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorRectItem.cs
@@ -14,6 +14,18 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         [SerializeField]
         NumericInputField[] m_SizeFields;
 
+        public NumericInputField[] centerFields
+        {
+            get { return m_CenterFields; }
+            set { m_CenterFields = value; }
+        }
+
+        public NumericInputField[] sizeFields
+        {
+            get { return m_SizeFields; }
+            set { m_SizeFields = value; }
+        }
+
         public override void Setup(InspectorData data)
         {
             base.Setup(data);

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorStringItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorStringItem.cs
@@ -6,8 +6,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class InspectorStringItem : InspectorPropertyItem
     {
+#pragma warning disable 649
         [SerializeField]
         StandardInputField m_InputField;
+#pragma warning restore 649
 
         public override void Setup(InspectorData data)
         {

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorUnimplementedItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorUnimplementedItem.cs
@@ -7,8 +7,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class InspectorUnimplementedItem : InspectorPropertyItem
     {
+#pragma warning disable 649
         [SerializeField]
         TextMeshProUGUI m_TypeLabel;
+#pragma warning restore 649
 
         public override void Setup(InspectorData data)
         {

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorVectorItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorVectorItem.cs
@@ -7,11 +7,13 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class InspectorVectorItem : InspectorPropertyItem
     {
+#pragma warning disable 649
         [SerializeField]
         GameObject ZGroup;
 
         [SerializeField]
         GameObject WGroup;
+#pragma warning restore 649
 
         public override void Setup(InspectorData data)
         {

--- a/Workspaces/InspectorWorkspace/Scripts/LockUI.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/LockUI.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
     {
         const string k_MaterialStencilRefProperty = "_StencilRef";
 
+#pragma warning disable 649
         [SerializeField]
         Image m_LockImage;
 
@@ -19,6 +20,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         WorkspaceButton m_Button;
+#pragma warning restore 649
 
         public byte stencilRef { get; set; }
 

--- a/Workspaces/LockedObjectsWorkspace/LockedObjectsWorkspace.cs
+++ b/Workspaces/LockedObjectsWorkspace/LockedObjectsWorkspace.cs
@@ -13,7 +13,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 #pragma warning disable 649
         [SerializeField]
         GameObject m_UnlockAllPrefab;
-#pragma warning disable 649
+#pragma warning restore 649
 
         string m_BaseSearchQuery;
         string m_CachedSearchQuery;

--- a/Workspaces/LockedObjectsWorkspace/LockedObjectsWorkspace.cs
+++ b/Workspaces/LockedObjectsWorkspace/LockedObjectsWorkspace.cs
@@ -10,8 +10,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
     [SpatialMenuItem("Locked Objects", "Workspaces", "View all locked objects in your scene(s)")]
     class LockedObjectsWorkspace : HierarchyWorkspace, IUsesGameObjectLocking
     {
+#pragma warning disable 649
         [SerializeField]
         GameObject m_UnlockAllPrefab;
+#pragma warning disable 649
 
         string m_BaseSearchQuery;
         string m_CachedSearchQuery;

--- a/Workspaces/MiniWorldWorkspace/MiniWorldWorkspace.cs
+++ b/Workspaces/MiniWorldWorkspace/MiniWorldWorkspace.cs
@@ -34,45 +34,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             }
         }
 
-        static readonly float k_InitReferenceYOffset = DefaultBounds.y / 2.05f; // Show more space above ground than below
-
-        static readonly Vector3 k_LocatePlayerOffset = new Vector3(0.1385f, 0.035f, -0.05f);
-        static readonly float k_LocatePlayerArrowOffset = 0.05f;
-
-        const float k_InitReferenceScale = 15f; // We want to see a big region by default
-
-        const string k_LeftActionString = "Move Resize Left";
-        const string k_RightActionString = "Move Resize Right";
-
-        const string k_MoveFeedbackString = "Move Miniworld View";
-        const string k_ScaleFeedbackString = "Scale Miniworld View";
-
-        // Scales larger or smaller than this spam errors in the console
-        const float k_MinScale = 0.01f;
-        const float k_MaxScale = 1e12f;
-
-        // Scale slider min/max (maps to referenceTransform uniform scale)
-        const float k_ZoomSliderMin = 0.5f;
-        const float k_ZoomSliderMax = 200f;
-
-        [SerializeField]
-        GameObject m_ContentPrefab;
-
-        [SerializeField]
-        GameObject m_RecenterUIPrefab;
-
-        [SerializeField]
-        GameObject m_LocatePlayerPrefab;
-
-        [SerializeField]
-        GameObject m_PlayerDirectionArrowPrefab;
-
-        [SerializeField]
-        GameObject m_ZoomSliderPrefab;
-
-        [SerializeField]
-        HapticPulse m_EnterExitPulse;
-
         [Serializable]
         class Preferences
         {
@@ -103,6 +64,47 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
                 set { m_ZoomSliderValue = value; }
             }
         }
+
+        static readonly float k_InitReferenceYOffset = DefaultBounds.y / 2.05f; // Show more space above ground than below
+
+        static readonly Vector3 k_LocatePlayerOffset = new Vector3(0.1385f, 0.035f, -0.05f);
+        static readonly float k_LocatePlayerArrowOffset = 0.05f;
+
+        const float k_InitReferenceScale = 15f; // We want to see a big region by default
+
+        const string k_LeftActionString = "Move Resize Left";
+        const string k_RightActionString = "Move Resize Right";
+
+        const string k_MoveFeedbackString = "Move Miniworld View";
+        const string k_ScaleFeedbackString = "Scale Miniworld View";
+
+        // Scales larger or smaller than this spam errors in the console
+        const float k_MinScale = 0.01f;
+        const float k_MaxScale = 1e12f;
+
+        // Scale slider min/max (maps to referenceTransform uniform scale)
+        const float k_ZoomSliderMin = 0.5f;
+        const float k_ZoomSliderMax = 200f;
+
+#pragma warning disable 649
+        [SerializeField]
+        GameObject m_ContentPrefab;
+
+        [SerializeField]
+        GameObject m_RecenterUIPrefab;
+
+        [SerializeField]
+        GameObject m_LocatePlayerPrefab;
+
+        [SerializeField]
+        GameObject m_PlayerDirectionArrowPrefab;
+
+        [SerializeField]
+        GameObject m_ZoomSliderPrefab;
+
+        [SerializeField]
+        HapticPulse m_EnterExitPulse;
+#pragma warning restore 649
 
         MiniWorldUI m_MiniWorldUI;
         MiniWorld m_MiniWorld;

--- a/Workspaces/MiniWorldWorkspace/Scripts/MiniWorldRenderer.cs
+++ b/Workspaces/MiniWorldWorkspace/Scripts/MiniWorldRenderer.cs
@@ -12,10 +12,19 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         const string k_MiniWorldCameraTag = "MiniWorldCamera";
         const float k_MinScale = 0.001f;
 
+        static int s_DefaultLayer;
+
+#pragma warning disable 649
         [SerializeField]
         Shader m_ClipShader;
+#pragma warning restore 649
 
-        static int s_DefaultLayer;
+        List<Renderer> m_IgnoreList = new List<Renderer>();
+
+        Camera m_MiniCamera;
+
+        int[] m_IgnoredObjectLayer;
+        bool[] m_IgnoreObjectRendererEnabled;
 
         public List<Renderer> ignoreList
         {
@@ -30,13 +39,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
                 }
             }
         }
-
-        List<Renderer> m_IgnoreList = new List<Renderer>();
-
-        Camera m_MiniCamera;
-
-        int[] m_IgnoredObjectLayer;
-        bool[] m_IgnoreObjectRendererEnabled;
 
         public MiniWorld miniWorld { private get; set; }
         public LayerMask cullingMask { private get; set; }

--- a/Workspaces/MiniWorldWorkspace/Scripts/MiniWorldUI.cs
+++ b/Workspaces/MiniWorldWorkspace/Scripts/MiniWorldUI.cs
@@ -4,20 +4,22 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     class MiniWorldUI : MonoBehaviour
     {
+#pragma warning disable 649
+        [SerializeField]
+        Renderer m_Grid;
+
+        [SerializeField]
+        Transform m_BoundsCube;
+#pragma warning restore 649
+
         public Renderer grid
         {
             get { return m_Grid; }
         }
 
-        [SerializeField]
-        private Renderer m_Grid;
-
         public Transform boundsCube
         {
             get { return m_BoundsCube; }
         }
-
-        [SerializeField]
-        private Transform m_BoundsCube;
     }
 }

--- a/Workspaces/MiniWorldWorkspace/Scripts/ResetUI.cs
+++ b/Workspaces/MiniWorldWorkspace/Scripts/ResetUI.cs
@@ -4,12 +4,14 @@ namespace UnityEditor.Experimental.EditorVR.UI
 {
     sealed class ResetUI : MonoBehaviour
     {
+#pragma warning disable 649
+        [SerializeField]
+        UnityEngine.UI.Button m_ResetButton;
+#pragma warning restore 649
+
         public UnityEngine.UI.Button resetButton
         {
             get { return m_ResetButton; }
         }
-
-        [SerializeField]
-        UnityEngine.UI.Button m_ResetButton;
     }
 }

--- a/Workspaces/PolyWorkspace/PolyWorkspace.cs
+++ b/Workspaces/PolyWorkspace/PolyWorkspace.cs
@@ -58,6 +58,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             }
         }
 
+#pragma warning disable 649
         [SerializeField]
         GameObject m_ContentPrefab;
 
@@ -66,6 +67,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         GameObject m_SliderPrefab;
+#pragma warning restore 649
 
         bool m_Scrolling;
 
@@ -409,8 +411,8 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         {
             var size = contentBounds.size;
             var gridView = m_PolyUI.gridView;
-            size.x -= DoubleFaceMargin; // Shrink the content width, so that there is space allowed to grab and scroll
-            size.z -= DoubleFaceMargin; // Reduce the height of the inspector contents as to fit within the bounds of the workspace
+            size.x -= k_DoubleFaceMargin; // Shrink the content width, so that there is space allowed to grab and scroll
+            size.z -= k_DoubleFaceMargin; // Reduce the height of the inspector contents as to fit within the bounds of the workspace
             gridView.size = size;
         }
 

--- a/Workspaces/PolyWorkspace/Scripts/PolyGridAsset.cs
+++ b/Workspaces/PolyWorkspace/Scripts/PolyGridAsset.cs
@@ -142,7 +142,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
     {
         public string url;
     }
-#else
-    #pragma warning restore 618
+    #pragma warning restore 649
 #endif
 }

--- a/Workspaces/PolyWorkspace/Scripts/PolyGridItem.cs
+++ b/Workspaces/PolyWorkspace/Scripts/PolyGridItem.cs
@@ -33,6 +33,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         const int k_AutoHidePreviewComplexity = 10000;
 
+#pragma warning disable 649
 #if INCLUDE_TEXT_MESH_PRO
         [SerializeField]
         TextMeshProUGUI m_Text;
@@ -56,6 +57,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         [HideInInspector]
         [SerializeField] // Serialized so that this remains set after cloning
         Transform m_PreviewObjectTransform;
+#pragma warning restore 649
 
         bool m_Setup;
         bool m_AutoHidePreview;

--- a/Workspaces/PolyWorkspace/Scripts/PolyGridViewController.cs
+++ b/Workspaces/PolyWorkspace/Scripts/PolyGridViewController.cs
@@ -13,6 +13,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         const float k_PositionFollow = 0.4f;
 
+#pragma warning disable 649
         [SerializeField]
         float m_ScaleFactor = 0.05f;
 
@@ -30,6 +31,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         GameObject[] m_Icons;
+#pragma warning restore 649
 
         Transform m_GrabbedObject;
 

--- a/Workspaces/PolyWorkspace/Scripts/PolyUI.cs
+++ b/Workspaces/PolyWorkspace/Scripts/PolyUI.cs
@@ -5,11 +5,13 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class PolyUI : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         PolyGridViewController m_GridView;
 
         [SerializeField]
         LinearHandle m_ScrollHandle;
+#pragma warning restore 649
 
         public PolyGridViewController gridView { get { return m_GridView; } }
         public LinearHandle scrollHandle { get { return m_ScrollHandle; } }

--- a/Workspaces/ProjectWorkspace/ProjectWorkspace.cs
+++ b/Workspaces/ProjectWorkspace/ProjectWorkspace.cs
@@ -27,6 +27,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         bool m_AssetGridDragging;
         bool m_FolderPanelDragging;
 
+#pragma warning disable 649
         [SerializeField]
         GameObject m_ContentPrefab;
 
@@ -35,6 +36,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         GameObject m_FilterPrefab;
+#pragma warning restore 649
 
         ProjectUI m_ProjectUI;
         FilterUI m_FilterUI;

--- a/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/AssetGridViewController.cs
@@ -1,6 +1,6 @@
+using ListView;
 using System;
 using System.Collections.Generic;
-using ListView;
 using UnityEditor.Experimental.EditorVR.Data;
 using UnityEditor.Experimental.EditorVR.Utilities;
 using UnityEngine;
@@ -11,9 +11,26 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
     {
         const float k_PositionFollow = 0.4f;
 
+#pragma warning disable 649
+        [SerializeField]
+        float m_ScaleFactor = 0.05f;
+
+        [SerializeField]
+        string[] m_IconTypes;
+
+        [SerializeField]
+        GameObject[] m_Icons;
+#pragma warning restore 649
+
         Transform m_GrabbedObject;
 
         int m_NumPerRow;
+
+        float m_LastHiddenItemOffset;
+
+        readonly Dictionary<string, GameObject> m_IconDictionary = new Dictionary<string, GameObject>();
+
+        Action<AssetGridItem> m_OnRecycleComplete;
 
         public float scaleFactor
         {
@@ -25,21 +42,6 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             }
         }
 
-        [SerializeField]
-        float m_ScaleFactor = 0.05f;
-
-        [SerializeField]
-        string[] m_IconTypes;
-
-        [SerializeField]
-        GameObject[] m_Icons;
-
-        float m_LastHiddenItemOffset;
-
-        readonly Dictionary<string, GameObject> m_IconDictionary = new Dictionary<string, GameObject>();
-
-        Action<AssetGridItem> m_OnRecyleComplete;
-
         public Func<string, bool> matchesFilter { private get; set; }
 
         protected override float listHeight
@@ -50,7 +52,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
                     return 0;
 
                 var numRows = Mathf.CeilToInt(m_Data.Count / m_NumPerRow);
-                return Mathf.Clamp(numRows, 1, Int32.MaxValue) * itemSize.z;
+                return Mathf.Clamp(numRows, 1, int.MaxValue) * itemSize.z;
             }
         }
 
@@ -75,7 +77,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         void Awake()
         {
-            m_OnRecyleComplete = OnRecycleComplete;
+            m_OnRecycleComplete = OnRecycleComplete;
         }
 
         protected override void Setup()
@@ -165,7 +167,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
             m_ListItems.Remove(index);
 
-            item.SetVisibility(false, m_OnRecyleComplete);
+            item.SetVisibility(false, m_OnRecycleComplete);
         }
 
         void OnRecycleComplete(AssetGridItem gridItem)

--- a/Workspaces/ProjectWorkspace/Scripts/FolderListItem.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/FolderListItem.cs
@@ -14,6 +14,7 @@ namespace UnityEditor.Experimental.EditorVR.Data
 
         const float k_ExpandArrowRotateSpeed = 0.4f;
 
+#pragma warning disable 649
         [SerializeField]
         TextMeshProUGUI m_Text;
 
@@ -34,6 +35,7 @@ namespace UnityEditor.Experimental.EditorVR.Data
 
         [SerializeField]
         Color m_SelectedColor;
+#pragma warning restore 649
 
         Color m_NormalColor;
 

--- a/Workspaces/ProjectWorkspace/Scripts/ProjectUI.cs
+++ b/Workspaces/ProjectWorkspace/Scripts/ProjectUI.cs
@@ -5,6 +5,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
     sealed class ProjectUI : MonoBehaviour
     {
+#pragma warning disable 649
         [SerializeField]
         FolderListViewController m_FolderListView;
 
@@ -22,6 +23,7 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 
         [SerializeField]
         WorkspaceHighlight m_FolderPanelHighlight;
+#pragma warning restore 649
 
         public FolderListViewController folderListView { get { return m_FolderListView; } }
         public LinearHandle folderScrollHandle { get { return m_FolderScrollHandle; } }


### PR DESCRIPTION
### Purpose of this PR

Fix warnings due to 2018.3 upgrade and default runtime becoming .NET 4.x

### Testing status

Tests pass locally. I no longer see EditorXR-related warnings when recompiling in-editor or making player builds. Did a basic smoke test in editor, play mode, and player build.

### Technical risk

Very low--mostly pre-processor defines and prefab API updates

### Comments to reviewers

That first commit is pretty hefty, so let me break down the changes:
- The new prefab workflow requires us to change `PrefabUtility.GetPrefabType` to `PrefabUtility.GetPrefabAssetType`, `PrefabUtility.CreatePrefab` to `PrefabUtility.SavePrefabAsset`, `PrefabUtility.FindPrefabRoot` to `PrefabUtility.GetOutermostPrefabInstanceRoot`, and `PrefabUtility.GetPrefabType` to `PrefabUtility.GetPrefabInstanceStatus`
- The process in AssetGridItem where we reconnect the preview object to its prefab is no longer viable. Instead, we must re-instantiate the preview with `PrefabUtility.InstantiatePrefab`. It is not possible to clone a non-prefab object whose children are prefabs and maintain prefab links.
- There were many places where private `SerializeField`s have no setters. This results in a CS0649 warning, which was suppressed in the legacy runtime. For now, I have used #pragma warning disable to suppress the warning in the new 4.x runtime. I could also have fixed this by adding public setters, but they would have been unused, and in many cases would have added a _lot_ of noise to our classes.
- The fixes for player builds came down to more aggressively adding #if UNITY_EDITOR, and working around code that should be editor-only.
- As I went along, I addressed spelling mistakes, unused fields, and field order issues that I came across.
- In doing a final audit of these warning directives, I found a few places where we had mismatched disable/restore directives, and fixed them.