### PR TITLE
Fix Context destroy bug

### DIFF
--- a/Scripts/Core/Contexts/EditingContextManager.cs
+++ b/Scripts/Core/Contexts/EditingContextManager.cs
@@ -28,7 +28,6 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
         IEditingContext m_CurrentContext;
 
-        internal static EditingContextManager s_Instance;
         static InputManager s_InputManager;
         static List<IEditingContext> s_AvailableContexts;
         static EditingContextManagerSettings s_Settings;
@@ -44,6 +43,8 @@ namespace UnityEditor.Experimental.EditorVR.Core
 
         Rect m_ContextPopupRect = new Rect(5, 0, 100, 20); // Position will be set based on window size
         Rect m_ContextLabelRect = new Rect(5, 0, 100, 20); // Position will be set based on window size
+
+        internal static EditingContextManager instance { get; private set; }
 
         internal static IEditingContext defaultContext
         {
@@ -102,13 +103,13 @@ namespace UnityEditor.Experimental.EditorVR.Core
             Resources.UnloadUnusedAssets();
             InitializeInputManager();
             if (!Application.isPlaying)
-                s_Instance = ObjectUtils.CreateGameObjectWithComponent<EditingContextManager>();
+                instance = ObjectUtils.CreateGameObjectWithComponent<EditingContextManager>();
         }
 
         static void OnVRViewDisabled()
         {
             s_AutoOpened = false;
-            ObjectUtils.Destroy(s_Instance.gameObject);
+            ObjectUtils.Destroy(instance.gameObject);
             if (s_InputManager)
                 ObjectUtils.Destroy(s_InputManager.gameObject);
         }
@@ -351,7 +352,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
             if (Application.isPlaying)
             {
                 OnVRViewEnabled();
-                s_Instance = this;
+                instance = this;
                 SetEditingContext((IEditingContext)m_DefaultContext);
             }
         }

--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -536,10 +536,7 @@ namespace UnityEditor.Experimental.EditorVR.Core
                 manager.gameObject.hideFlags = hideFlags;
             }
 
-            foreach (var manager in Resources.FindObjectsOfTypeAll<EditingContextManager>())
-            {
-                manager.gameObject.hideFlags = hideFlags;
-            }
+            EditingContextManager.instance.gameObject.hideFlags = hideFlags;
 
             foreach (var child in GetComponentsInChildren<Transform>(true))
             {

--- a/Tests/Editor/Unit/Core/EditingContextManagerTests.cs
+++ b/Tests/Editor/Unit/Core/EditingContextManagerTests.cs
@@ -21,7 +21,7 @@ namespace UnityEditor.Experimental.EditorVR.Tests.Core
         [OneTimeSetUp]
         public void Setup()
         {
-            manager = EditingContextManager.s_Instance;
+            manager = EditingContextManager.instance;
             go = new GameObject("context test object");
             var transformTool = go.AddComponent<TransformTool>();
             var createPrimitiveTool = go.AddComponent<CreatePrimitiveTool>();


### PR DESCRIPTION
### Purpose of this PR

Fix an issue where the in-scene context manager object can get destroyed or appear multiple times. Fixes #530 

### Testing status

This issue is difficult to reproduce. What was happening is that starting EXR in edit-mode would set hideflags on all ContextManagers to `DontSaveInEditor`, meaning that the one from your open scene, as well as the one that EXR just created got these hideflags. Closing the window would destroy the new context manager object, but not restore the hideflags on the one in your scene. Then, when you _change scenes_, your original context would not be destroyed, resulting in two of these objects existing while only one showed up in the hierearchy. If you entered play mode, you would get hideflags of `None` set on all EditingContextManagers, causing the second object to appear in the hierarchy. It was possible to "build up" a number of context objects this way.

In the reverse, what would happen is simply that, once you got your in-scene editing context manager's hideflags set to `DontSaveInEditor`, the object will disappear once you enter Play Mode. For some reason this also causes it to get ignored in builds, and will not execute its scripts in play mode. The object still _exists_ but it doesn't do anything.

I was able to figure this out by creating an editor window with the following code:
```
var managers = Resources.FindObjectsOfTypeAll<EditingContextManager>();
foreach (var manager in managers)
{
    GUILayout.Label(manager.name + ", " + manager.gameObject.hideFlags);
}
```

### Technical risk

Medium -- I'm not sure there was a particularly good reason why we were setting hide flags on >1 EditingContextManager in the first place.

### Comments to reviewers

So glad to have squashed this bug. It was a tricky one, so it there may be some edge cases I'm missing.
For some reason this view https://github.com/Unity-Technologies/SuperScience#hiddenhierarchy-find-hidden-scene-objects didn't show those hidden editing context manager objects. I had to specifically use `Resources.FindObjectsOfTypeAll<EditingContextManager>()` for it to show up.