### PR TITLE
Intersection Module Fixes

### DIFF
--- a/Scripts/Utilities/IntersectionUtils.cs
+++ b/Scripts/Utilities/IntersectionUtils.cs
@@ -275,11 +275,23 @@ namespace UnityEditor.Experimental.EditorVR.Utilities
             var mf = obj.GetComponent<MeshFilter>();
             if (mf)
             {
-                if (collisionTester.sharedMesh != mf.sharedMesh)
-                {
-                    collisionTester.sharedMesh = mf.sharedMesh;
-                    collisionTester.transform.localScale = Vector3.one;
-                }
+                var mesh = mf.sharedMesh;
+
+#if !UNITY_EDITOR
+                // Player builds throw errors for non-readable meshes
+                if (!mesh.isReadable)
+                    return;
+#endif
+
+                // Non-triangle meshes cause physics error
+                if (mesh.GetTopology(0) != MeshTopology.Triangles)
+                    return;
+
+                if (collisionTester.sharedMesh == mesh)
+                    return;
+
+                collisionTester.sharedMesh = mf.sharedMesh;
+                collisionTester.transform.localScale = Vector3.one;
 
                 return;
             }


### PR DESCRIPTION
### Purpose of this PR

Fix errors in Player builds when rays hover over non-readable meshes; Fix errors when hovering over non-triangle meshes (closes #492, closes #531 )

### Testing status

Tested by hovering a non-triangle mesh in the Editor, and using the Synty Adventure scene in a Player build.

### Technical risk

Low--only rules out mesh collision tests

### Comments to reviewers

Easy fix :)