### PR TITLE
Fix errors in player builds related to serialization

### DIFF
--- a/Scripts/Helpers/EditorWindowCapture.cs
+++ b/Scripts/Helpers/EditorWindowCapture.cs
@@ -1,5 +1,4 @@
-﻿#if UNITY_EDITOR
-using System;
+﻿using System;
 using System.Reflection;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -10,6 +9,7 @@ using System.Threading;
 
 namespace UnityEditor.Experimental.EditorVR.Helpers
 {
+#if UNITY_EDITOR
     /// <summary>
     /// Captures a RenderTexture representing an Editor window
     /// </summary>
@@ -179,5 +179,9 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
         public static extern int SendMessage(IntPtr hWnd, int uMsg, int wParam, IntPtr lParam);
 #endif
     }
-}
+#else
+    sealed class EditorWindowCapture : MonoBehaviour
+    {
+    }
 #endif
+}

--- a/Scripts/Helpers/EditorWindowCaptureUpdater.cs
+++ b/Scripts/Helpers/EditorWindowCaptureUpdater.cs
@@ -1,10 +1,10 @@
-﻿#if UNITY_EDITOR
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UI;
 using UnityEditor.Experimental.EditorVR.Utilities;
 
 namespace UnityEditor.Experimental.EditorVR.Helpers
 {
+#if UNITY_EDITOR
     /// <summary>
     /// Updates a RawImage texture with data from an EditorWindowCapture
     /// </summary>
@@ -88,5 +88,20 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
             }
         }
     }
-}
+#else
+    sealed class EditorWindowCaptureUpdater : MonoBehaviour
+    {
+        [SerializeField]
+        EditorWindowCapture m_EditorWindowCapture;
+
+        [SerializeField]
+        RawImage m_RawImage;
+
+        [SerializeField]
+        Material m_Material;
+
+        [SerializeField]
+        bool m_LockAspect;
+    }
 #endif
+}

--- a/Scripts/Helpers/VRSmoothCamera.cs
+++ b/Scripts/Helpers/VRSmoothCamera.cs
@@ -1,10 +1,10 @@
-﻿#if UNITY_EDITOR
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEditor.Experimental.EditorVR.Core;
 using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Helpers
 {
+#if UNITY_EDITOR
     /// <summary>
     /// A preview camera that provides for smoothing of the position and look vector
     /// </summary>
@@ -23,7 +23,8 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
         [SerializeField]
         int m_TargetDisplay;
 
-        [SerializeField, Range(1, 180)]
+        [Range(1, 180)]
+        [SerializeField]
         int m_FieldOfView = 40;
 
         [SerializeField]
@@ -141,5 +142,25 @@ namespace UnityEditor.Experimental.EditorVR.Helpers
             }
         }
     }
-}
+#else
+    sealed class VRSmoothCamera : MonoBehaviour
+    {
+#pragma warning disable 649
+        [SerializeField]
+        Camera m_VRCamera;
+
+        [SerializeField]
+        int m_TargetDisplay;
+
+        [SerializeField]
+        int m_FieldOfView = 40;
+
+        [SerializeField]
+        float m_PullBackDistance = 0.8f;
+
+        [SerializeField]
+        float m_SmoothingMultiplier = 3;
+#pragma warning restore 649
+    }
 #endif
+}

--- a/Scripts/Modules/HierarchyModule.cs
+++ b/Scripts/Modules/HierarchyModule.cs
@@ -1,5 +1,4 @@
-﻿#if UNITY_EDITOR
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor.Experimental.EditorVR.Core;
@@ -7,6 +6,7 @@ using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Modules
 {
+#if UNITY_EDITOR
     sealed class HierarchyModule : MonoBehaviour, ISystemModule, ISelectionChanged
     {
         readonly List<IUsesHierarchyData> m_HierarchyLists = new List<IUsesHierarchyData>();
@@ -260,5 +260,9 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             }
         }
     }
-}
+#else
+    sealed class HierarchyModule : MonoBehaviour
+    {
+    }
 #endif
+}

--- a/Scripts/Modules/ProjectFolderModule.cs
+++ b/Scripts/Modules/ProjectFolderModule.cs
@@ -1,4 +1,3 @@
-#if UNITY_EDITOR
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -9,6 +8,7 @@ using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Modules
 {
+#if UNITY_EDITOR
     sealed class ProjectFolderModule : MonoBehaviour, ISystemModule
     {
         // Maximum time (in ms) before yielding in CreateFolderData: should be target frame time
@@ -188,5 +188,9 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             return new AssetData(hp.name, hp.guid, typeName);
         }
     }
-}
+#else
+    sealed class ProjectFolderModule : MonoBehaviour
+    {
+    }
 #endif
+}

--- a/Workspaces/Common/Scripts/EditorWindowWorkspace.cs
+++ b/Workspaces/Common/Scripts/EditorWindowWorkspace.cs
@@ -1,10 +1,10 @@
-﻿#if UNITY_EDITOR
-using UnityEditor.Experimental.EditorVR.Handles;
+﻿using UnityEditor.Experimental.EditorVR.Handles;
 using UnityEditor.Experimental.EditorVR.Helpers;
 using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
+#if UNITY_EDITOR
     abstract class EditorWindowWorkspace : Workspace
     {
 #pragma warning disable 649
@@ -67,5 +67,11 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             m_Capture.SendEvent(eventData.rayOrigin, transform, EventType.MouseUp);
         }
     }
-}
+#else
+    abstract class EditorWindowWorkspace : Workspace
+    {
+        [SerializeField]
+        GameObject m_CaptureWindowPrefab;
+    }
 #endif
+}

--- a/Workspaces/ConsoleWorkspace/ConsoleWorkspace.cs
+++ b/Workspaces/ConsoleWorkspace/ConsoleWorkspace.cs
@@ -1,10 +1,12 @@
-﻿#if UNITY_EDITOR
-namespace UnityEditor.Experimental.EditorVR.Workspaces
+﻿namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
+#if UNITY_EDITOR
     [MainMenuItem("Console", "Workspaces", "View errors, warnings and other messages")]
     [SpatialMenuItem("Console", "Workspaces", "View errors, warnings and other messages")]
+#else
+    [EditorOnlyWorkspace]
+#endif
     sealed class ConsoleWorkspace : EditorWindowWorkspace
     {
     }
 }
-#endif

--- a/Workspaces/InspectorWorkspace/InspectorWorkspace.cs
+++ b/Workspaces/InspectorWorkspace/InspectorWorkspace.cs
@@ -1,4 +1,3 @@
-#if UNITY_EDITOR
 using System.Collections.Generic;
 using UnityEditor.Experimental.EditorVR.Data;
 using UnityEditor.Experimental.EditorVR.Handles;
@@ -7,11 +6,10 @@ using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
+#if UNITY_EDITOR
     [MainMenuItem("Inspector", "Workspaces", "View and edit GameObject properties")]
     sealed class InspectorWorkspace : Workspace, ISelectionChanged, IInspectorWorkspace
     {
-        public new static readonly Vector3 DefaultBounds = new Vector3(0.3f, 0.1f, 0.5f);
-
 #pragma warning disable 649
         [SerializeField]
         GameObject m_ContentPrefab;
@@ -391,5 +389,15 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
                 UpdateCurrentObject(fullRebuild);
         }
     }
-}
+#else
+    [EditorOnlyWorkspace]
+    sealed class InspectorWorkspace : Workspace
+    {
+        [SerializeField]
+        GameObject m_ContentPrefab;
+
+        [SerializeField]
+        GameObject m_LockPrefab;
+    }
 #endif
+}

--- a/Workspaces/InspectorWorkspace/Scripts/InspectorListViewController.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/InspectorListViewController.cs
@@ -1,5 +1,4 @@
-﻿#if UNITY_EDITOR
-using ListView;
+﻿using ListView;
 using System;
 using System.Collections.Generic;
 using UnityEditor.Experimental.EditorVR.Data;
@@ -8,6 +7,7 @@ using UnityEngine;
 
 namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
+#if UNITY_EDITOR
     sealed class InspectorListViewController : NestedListViewController<InspectorData, InspectorListItem, int>, IUsesGameObjectLocking, IUsesStencilRef
     {
         const string k_MaterialStencilRef = "_StencilRef";
@@ -311,5 +311,35 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             ObjectUtils.Destroy(m_NoClipHighlightMaskMaterial);
         }
     }
-}
+#else
+    sealed class InspectorListViewController : NestedListViewController<InspectorData, InspectorListItem, int>
+    {
+        [SerializeField]
+        Material m_RowCubeMaterial;
+
+        [SerializeField]
+        Material m_BackingCubeMaterial;
+
+        [SerializeField]
+        Material m_UIMaterial;
+
+        [SerializeField]
+        Material m_UIMaskMaterial;
+
+        [SerializeField]
+        Material m_NoClipBackingCubeMaterial;
+
+        [SerializeField]
+        Material m_HighlightMaterial;
+
+        [SerializeField]
+        Material m_HighlightMaskMaterial;
+
+        [SerializeField]
+        Material m_NoClipHighlightMaterial;
+
+        [SerializeField]
+        Material m_NoClipHighlightMaskMaterial;
+    }
 #endif
+}

--- a/Workspaces/InspectorWorkspace/Scripts/InspectorUI.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/InspectorUI.cs
@@ -1,9 +1,9 @@
-﻿#if UNITY_EDITOR
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEditor.Experimental.EditorVR.Handles;
 
 namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
+#if UNITY_EDITOR
     sealed class InspectorUI : MonoBehaviour
     {
 #pragma warning disable 649
@@ -32,5 +32,17 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             get { return m_ListView; }
         }
     }
-}
+#else
+    sealed class InspectorUI : MonoBehaviour
+    {
+        [SerializeField]
+        InspectorListViewController m_ListView;
+
+        [SerializeField]
+        LinearHandle m_ScrollHandle;
+
+        [SerializeField]
+        RectTransform m_ListPanel;
+    }
 #endif
+}

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorHeaderItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorHeaderItem.cs
@@ -1,5 +1,4 @@
-﻿#if UNITY_EDITOR
-using System;
+﻿using System;
 using System.Collections;
 using System.Linq;
 using UnityEditor.Experimental.EditorVR.Data;
@@ -10,6 +9,7 @@ using InputField = UnityEditor.Experimental.EditorVR.UI.InputField;
 
 namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
+#if UNITY_EDITOR
     sealed class InspectorHeaderItem : InspectorListItem
     {
 #pragma warning disable 649
@@ -190,5 +190,32 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
 #endif
         }
     }
-}
+#else
+    sealed class InspectorHeaderItem : InspectorListItem
+    {
+        [SerializeField]
+        RawImage m_Icon;
+
+        [SerializeField]
+        Toggle m_ActiveToggle;
+
+        [SerializeField]
+        StandardInputField m_NameField;
+
+        [SerializeField]
+        Toggle m_StaticToggle;
+
+        [SerializeField]
+        Toggle m_LockToggle;
+
+        [SerializeField]
+        DropDown m_TagDropDown;
+
+        [SerializeField]
+        DropDown m_LayerDropDown;
+
+        [SerializeField]
+        MeshRenderer m_Button;
+    }
 #endif
+}

--- a/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorObjectFieldItem.cs
+++ b/Workspaces/InspectorWorkspace/Scripts/ListItems/InspectorObjectFieldItem.cs
@@ -1,5 +1,4 @@
-﻿#if UNITY_EDITOR
-using System;
+﻿using System;
 using TMPro;
 using UnityEditor.Experimental.EditorVR.Data;
 using UnityEditor.Experimental.EditorVR.Utilities;
@@ -8,6 +7,7 @@ using Object = UnityEngine.Object;
 
 namespace UnityEditor.Experimental.EditorVR.Workspaces
 {
+#if UNITY_EDITOR
     sealed class InspectorObjectFieldItem : InspectorPropertyItem
     {
 #pragma warning disable 649
@@ -115,5 +115,14 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             return obj == null || obj.GetType().IsAssignableFrom(m_ObjectType);
         }
     }
-}
+#else
+    sealed class InspectorObjectFieldItem : InspectorPropertyItem
+    {
+        [SerializeField]
+        TextMeshProUGUI m_FieldLabel;
+
+        [SerializeField]
+        MeshRenderer m_Button;
+    }
 #endif
+}


### PR DESCRIPTION
### Purpose of this PR

Fix common errors in Player builds

### Testing status

Tested in a Windows standalone Development build--there were a number of errors on first launch of EXR, and now there are none until you open Main Menu. The Main Menu error is shader-related, but I could not find a cause/fix. Creating an issue for later (#543)

### Technical risk

Low--fills in fallback MonoBehaviour classes for scripts that are saved in DefaultScriptReferences, or otherwise available at runtime but not used.

### Comments to reviewers

As discussed, an alternate approach would be to only compile-in the list of fields, instead of creating an entirely alternate version of the class, but I find this approach to be more readable in the 99% of the time where you are actually working on the non-stub version of the class.
