### PR TITLE
Prevent MainMenu ScrollRect elements from throwing an exception in runtime builds

### DIFF
--- a/Menus/MainMenu/Shaders/AngledVerticalGradientUIClip.shader
+++ b/Menus/MainMenu/Shaders/AngledVerticalGradientUIClip.shader
@@ -14,6 +14,7 @@
         _ColorMask("Color Mask", Float) = 15
 
         [Toggle(UNITY_UI_ALPHACLIP)] _UseUIAlphaClip("Use Alpha Clip", Float) = 0
+        _MainTex("Main Texture", 2D) = "white" {}
     }
 
     SubShader

--- a/Menus/MainMenu/Shaders/AngledVerticalGradientUIClip.shader
+++ b/Menus/MainMenu/Shaders/AngledVerticalGradientUIClip.shader
@@ -14,7 +14,7 @@
         _ColorMask("Color Mask", Float) = 15
 
         [Toggle(UNITY_UI_ALPHACLIP)] _UseUIAlphaClip("Use Alpha Clip", Float) = 0
-        _MainTex("Main Texture", 2D) = "white" {}
+        [HideInInspector]_MainTex("Main Texture", 2D) = "white" {}
     }
 
     SubShader

--- a/Menus/MainMenu/Shaders/AngledVerticalGradientUIClip.shader
+++ b/Menus/MainMenu/Shaders/AngledVerticalGradientUIClip.shader
@@ -16,7 +16,7 @@
         [Toggle(UNITY_UI_ALPHACLIP)] _UseUIAlphaClip("Use Alpha Clip", Float) = 0
 
         // Unused _MainTex property, added to prevent runtime exceptions for elements whose parent is a ScrollRect
-        [HideInInspector]_MainTex("Main Texture - unused", 2D) = "white" {}
+        [HideInInspector] _MainTex("Main Texture - unused", 2D) = "white" {}
     }
 
     SubShader

--- a/Menus/MainMenu/Shaders/AngledVerticalGradientUIClip.shader
+++ b/Menus/MainMenu/Shaders/AngledVerticalGradientUIClip.shader
@@ -14,7 +14,9 @@
         _ColorMask("Color Mask", Float) = 15
 
         [Toggle(UNITY_UI_ALPHACLIP)] _UseUIAlphaClip("Use Alpha Clip", Float) = 0
-        [HideInInspector]_MainTex("Main Texture", 2D) = "white" {}
+
+        // Unused _MainTex property, added to prevent runtime exceptions for elements whose parent is a ScrollRect
+        [HideInInspector]_MainTex("Main Texture - unused", 2D) = "white" {}
     }
 
     SubShader


### PR DESCRIPTION
### Purpose of this PR

Prevent some MainMenu ScrollRect elements that utilize the "AngledVerticalGradientUIClip" shader from throwing a shader-based (no _MainTex) exception in runtime builds.  This PR adds a _MainTex property to the AngledVerticalGradientUIClip shader, and hides it in the inspector (as it is unused, but remedies the exception being thrown).

Closes #543 

### Testing status

Tested using the previous repro: make build, enter session, open main menu.  The issue is no longer present in runtime builds.

### Technical risk

Low.  This PR just adds a hidden _MainTex property to a shader.

### Comments to reviewers

None