### PR TITLE
Fix Multi-Select Action on Vive

### DIFF
--- a/Menus/UndoMenu/UndoMenu.cs
+++ b/Menus/UndoMenu/UndoMenu.cs
@@ -113,7 +113,9 @@ namespace UnityEditor.Experimental.EditorVR.Menus
             if (!(engage.wasJustPressed || !m_TrackpadController && (engage.isHeld || m_StillEngagedAfterStickRelease)))
                 return;
 
-            consumeControl(engage);
+            if (!m_TrackpadController)
+                consumeControl(engage);
+
             m_UndoMenuUI.engaged = true;
 
             var navigateXControl = undoMenuInput.navigateX;


### PR DESCRIPTION
### Purpose of this PR

Fix the double-tap-stick multi-select action on Vive

### Testing status

Tested on Vive. There was no way to multi-select (engage blue ray). Now, double-tapping the touchpad will engage multi-select

### Technical / Halo risk

Tech Risk - 1 (Low)
Halo Risk - 0 (None)

### Comments to reviewers

I had a branch sitting around since last year `bugfixes/schoen/vive-multi-select`, but never opened a PR. I had to remind myself why this was a fix. On Vive, we use a different multi-select button because double-tapping the grip is difficult. However, when we added the Undo menu at top priority, it consumed all stick presses, blocking this action. We simply do not consume the stick press to fix this.
