### PR TITLE
Misc Improvements

### DIFF
--- a/Prefabs/SmoothCamera.prefab
+++ b/Prefabs/SmoothCamera.prefab
@@ -91,5 +91,5 @@ MonoBehaviour:
   m_VRCamera: {fileID: 20000011108369806}
   m_TargetDisplay: 0
   m_FieldOfView: 40
-  m_PullBackDistance: 0.8
+  m_PullBackDistance: 0.6
   m_SmoothingMultiplier: 3

--- a/Scripts/Modules/HighlightModule/HighlightModule.cs
+++ b/Scripts/Modules/HighlightModule/HighlightModule.cs
@@ -101,6 +101,14 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 }
             }
 
+            foreach (var obj in Selection.gameObjects)
+            {
+                if (!obj)
+                    continue;
+
+                HighlightObject(obj, m_RayHighlightMaterial);
+            }
+
             foreach (var kvp in k_HighlightsToRemove)
             {
                 var highlights = m_Highlights[kvp.Key];
@@ -223,7 +231,8 @@ namespace UnityEditor.Experimental.EditorVR.Modules
             {
                 SetHighlight(go, active, rayOrigin, null, true);
                 m_Blinking.Clear();
-                // using StopAll assumes that we're only allowing one simultaneous blinking highlight
+
+                // Using StopAll assumes that we're only allowing one simultaneous blinking highlight
                 StopAllCoroutines();
                 return null;
             }
@@ -256,6 +265,5 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 yield return null;
             }
         }
-
     }
 }

--- a/Scripts/Modules/SnappingModule/SnappingModule.cs
+++ b/Scripts/Modules/SnappingModule/SnappingModule.cs
@@ -34,7 +34,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
         const float k_MaxRayDot = -0.5f;
         const float k_RayExtra = 0.02f;
 
-        const float k_WidgetScale = 0.03f;
+        const float k_WidgetScale = 0.02f;
 
         const string k_MaterialColorLeftProperty = "_ColorLeft";
         const string k_MaterialColorRightProperty = "_ColorRight";
@@ -102,6 +102,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                         transform.transform.RotateAround(position, axis, angle);
                     }
                 }
+
                 identityBounds.center -= position;
                 this.identityBounds = identityBounds;
             }
@@ -728,6 +729,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                     return true;
                 }
             }
+
             return false;
         }
 
@@ -844,6 +846,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 state = new SnappingState(transforms, position, rotation);
                 states[firstObject] = state;
             }
+
             return state;
         }
 
@@ -856,6 +859,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                 {
                     kvp.Value.OnDestroy();
                 }
+
                 m_SnappingStates.Remove(rayOrigin);
             }
         }
@@ -869,6 +873,7 @@ namespace UnityEditor.Experimental.EditorVR.Modules
                     kvp.Value.OnDestroy();
                 }
             }
+
             m_SnappingStates.Clear();
         }
 

--- a/Workspaces/MiniWorldWorkspace/MiniWorld.prefab
+++ b/Workspaces/MiniWorldWorkspace/MiniWorld.prefab
@@ -198,7 +198,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_RendererCullingMask:
     serializedVersion: 2
-    m_Bits: 4294966751
+    m_Bits: 23
   m_ReferenceTransform: {fileID: 0}
 --- !u!114 &114000012428583066
 MonoBehaviour:


### PR DESCRIPTION
### Purpose of this PR

Add remaining improvements from Siggraph 2017

### Testing status

Changes were in use during presentation and prep. We just never had a chance to merge them in

### Technical / Halo risk

Tech Risk: 1 - Minimal tweaks

Halo Risk 0

### Comments to reviewers

Parent PR:
EditorXR: https://github.cds.internal.unity3d.com/unity/EditorXR-Project/pull/5

Included in this update:
- Add the Timer ProxyExtra which adds an interactive timer to your left hand for doing demos and presentations in VR. You can use it by adding it to the EditorVR asset importer.
- Hide HMDOnly layer in Miniworld to hide proxy extras
- Use HighlightModule to highlight selected objects in presentation camera (and also in all other cameras, meaning you can disable the editor selection highlight as well and still see the selection
- Slightly reduces the smooth camera pull-back distance so it's less swingy and doesn't go inside of objects behind you as easily
- Slightly decreases the size of the snapping "widget" sphere for better presentation of snapping feature