### PR TITLE
Staging Prep 0.3

### DIFF
--- a/Patches/Asmdef_Dependencies_Pre_2019_1.unitypackage
+++ b/Patches/Asmdef_Dependencies_Pre_2019_1.unitypackage
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:92141740e6a868417b9d76f3cef3dd6acae8d91c8525a7d98cdbbadefe751a9c
-size 1462

--- a/Patches/PolyToolkit_asmdef.unitypackage
+++ b/Patches/PolyToolkit_asmdef.unitypackage
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e43ac761d1b09682c67f31688b8311010456ec799223ea13f8ff33289721b3c
+size 771

--- a/Patches/PolyToolkit_asmdef.unitypackage.meta
+++ b/Patches/PolyToolkit_asmdef.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9d8a8043219ecc2468e7d901b7eff3ff
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Patches/SpatialTracking_2018.4.unitypackage
+++ b/Patches/SpatialTracking_2018.4.unitypackage
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e3581333ae4af126957d8a0e67c5931d819a3ca176ec387094711973ff14398
+size 627

--- a/Patches/SpatialTracking_2018.4.unitypackage.meta
+++ b/Patches/SpatialTracking_2018.4.unitypackage.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6abfefbdb52a5274ba0e5293dfe29473
+guid: 06d3631214f49e044a2e0f9fcf6dc5b6
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ If you're a developer, we recommend that you take a look at the [Getting Started
 - [git-lfs](https://git-lfs.github.com/)
 - [git-submodule](https://git-scm.com/docs/git-submodule)
 
-### Project Asset Dependencies
+### Project Package Dependencies
 - [Textmesh Pro](https://docs.unity3d.com/Packages/com.unity.textmeshpro@1.2/manual/index.html#installation)
 - [Legacy Input Helpers](https://docs.unity3d.com/Packages/com.unity.xr.legacyinputhelpers@1.0/manual/index.html#installing-comunityxrlegacyinputhelpers) (2019.1+)
-  - Users of 2018.3 do not need Legacy Input Helpers
+  - Users of 2018.4 do not need Legacy Input Helpers
 
 ### Cloning
 1. Create a new Unity project or use an existing one
@@ -46,11 +46,13 @@ Optionally, you could add a [git hook for post-checkout](https://ttboj.wordpress
 If you plan on making changes to EditorXR and/or contributing back, then you'll need to set the `Asset Serialization` property under Edit->Project Settings->Editor to `Force Text`.
 
 ### Assembly Definitions
-In order to support a variety of platform configurations, and to optionally strip its code out of player builds, EditorXR uses assembly definitions. Some of EditorXR's dependencies do not include assembly definitions in their current forms, so after importing EditorXR (in Unity 2018.3 and below), you must add them.
+In order to support a variety of platform configurations, and to optionally strip its code out of player builds, EditorXR uses assembly definitions. Some of EditorXR's dependencies do not include assembly definitions in their current forms, so after importing EditorXR (in Unity 2018.4), you must add them.
 
-For easy set-up, EditorXR includes a .unitypackage (`Patches/Dependencies_asmdef.unitypackage`) containing an assembly definition for the PolyToolkit and UnityEngine.SpatialTracking, which are referenced by EditorXR. Simply import it via Assets > Import Package > Custom Package...
+For easy set-up when cloning the repository, EditorXR includes two `.unitypackage` files (`Patches/PolyToolkit_asmdef.unitypackage` and `Patches/SpatialTracking_2018.4.unitypackage`) containing assembly definitions for the Google Poly Toolkit and UnityEngine.SpatialTracking, which are referenced by EditorXR. Simply import them via Assets > Import Package > Custom Package...
+- **For all Unity versions**: import the `PolyToolkit_asmdef` package to add assembly definitions to the PolyToolkit folder if you wish to integrate the PolyToolkit from the Asset Store
+- **For Unity 2018.4**: Import both the `PolyToolkit_asmdef` *and* `SpatialTracking_2018.4` packages to fix compile errors that occur due to missing package dependencies
 
-This is not required for Unity versions 2019.1 and above, though you will need to add an assembly definition in order to reference PolyToolkit.
+If you are using the release package, you will need to *delete* the `UnityEngine.SpatialTracking` assembly definition to prevent it from conflicting with the assembly definiton from the `Legacy Input Helpers` package, which will be automatically imported when you import EditorXR.
 
 ## All contributions are subject to the [Unity Contribution Agreement (UCA)](https://unity3d.com/legal/licenses/Unity_Contribution_Agreement)
 By making a pull request, you are confirming agreement to the terms and conditions of the UCA, including that your Contributions are your original creation and that you have complete right and authority to make your Contributions.

--- a/Scripts/Core/EditorVR.cs
+++ b/Scripts/Core/EditorVR.cs
@@ -559,34 +559,28 @@ namespace UnityEditor.Experimental.EditorVR.Core
         }
 #endif
     }
-#elif !(UNITY_2018_4_OR_NEWER || UNITY_2019_1_OR_NEWER)
-#if UNITY_EDITOR
-    [InitializeOnLoad]
-#endif
-    class EditorVR
+#else
+    sealed partial class EditorVR : MonoBehaviour
     {
-        const string k_ShowCustomEditorWarning = "EditorVR.ShowCustomEditorWarning";
+#pragma warning disable 649
+        [SerializeField]
+        MonoBehaviour m_ProxyRayPrefab;
 
-        static EditorVR()
-        {
-            if (EditorPrefs.GetBool(k_ShowCustomEditorWarning, true))
-            {
-                var message = "EditorXR requires Unity 2018.4 or the latest, non-beta version of Unity.";
-                var result = EditorUtility.DisplayDialogComplex("Update Unity", message, "Download", "Ignore", "Remind Me Again");
-                switch (result)
-                {
-                    case 0:
-                        Application.OpenURL("https://unity3d.com/get-unity/download");
-                        break;
-                    case 1:
-                        EditorPrefs.SetBool(k_ShowCustomEditorWarning, false);
-                        break;
-                    case 2:
-                        Debug.Log("<color=orange>" + message + "</color>");
-                        break;
-                }
-            }
-        }
+        [SerializeField]
+        ScriptableObject m_ProxyExtras;
+
+        [SerializeField]
+        Camera m_EventCameraPrefab;
+
+        [SerializeField]
+        GameObject m_PlayerModelPrefab;
+
+        [SerializeField]
+        GameObject m_PlayerFloorPrefab;
+
+        [SerializeField]
+        GameObject m_PreviewCameraPrefab;
+#pragma warning restore 649
     }
 #endif
 }

--- a/Scripts/Utilities/Editor/EXR-Utilities-Editor.asmdef
+++ b/Scripts/Utilities/Editor/EXR-Utilities-Editor.asmdef
@@ -1,10 +1,14 @@
 {
     "name": "EXR-Utilities-Editor",
-    "references": [
-        "EXR"
-    ],
+    "references": [],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
-    "excludePlatforms": []
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
 }

--- a/Scripts/Utilities/Editor/VersionCheck.cs
+++ b/Scripts/Utilities/Editor/VersionCheck.cs
@@ -1,0 +1,33 @@
+﻿#if !(UNITY_2018_4_OR_NEWER || UNITY_2019_1_OR_NEWER)
+using UnityEngine;
+
+namespace UnityEditor.Experimental.EditorVR.Core
+{
+    [InitializeOnLoad]
+    class VersionCheck
+    {
+        const string k_ShowCustomEditorWarning = "EditorVR.ShowCustomEditorWarning";
+
+        static VersionCheck()
+        {
+            if (EditorPrefs.GetBool(k_ShowCustomEditorWarning, true))
+            {
+                var message = "EditorXR requires Unity 2018.4 or the latest, non-beta version of Unity.";
+                var result = EditorUtility.DisplayDialogComplex("Update Unity", message, "Download", "Ignore", "Remind Me Again");
+                switch (result)
+                {
+                    case 0:
+                        Application.OpenURL("https://unity3d.com/get-unity/download");
+                        break;
+                    case 1:
+                        EditorPrefs.SetBool(k_ShowCustomEditorWarning, false);
+                        break;
+                    case 2:
+                        Debug.Log("<color=orange>" + message + "</color>");
+                        break;
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Scripts/Utilities/Editor/VersionCheck.cs.meta
+++ b/Scripts/Utilities/Editor/VersionCheck.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a47596688951b3c46bde336d85589b9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Workspaces/PolyWorkspace/Scripts/PolyGridAsset.cs
+++ b/Workspaces/PolyWorkspace/Scripts/PolyGridAsset.cs
@@ -40,10 +40,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
         public bool initialized { get { return m_Initialized; } }
         public long complexity { get { return m_Complexity; } }
 
+#if INCLUDE_POLY_TOOLKIT
         public event Action<PolyGridAsset, GameObject> modelImportCompleted;
         public event Action<PolyGridAsset, Texture2D> thumbnailImportCompleted;
 
-#if INCLUDE_POLY_TOOLKIT
         static PolyGridAsset()
         {
             s_Options = PolyImportOptions.Default();

--- a/Workspaces/PolyWorkspace/Scripts/PolyGridItem.cs
+++ b/Workspaces/PolyWorkspace/Scripts/PolyGridItem.cs
@@ -189,8 +189,10 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
                 if (!data.initialized)
                     data.Initialize();
 
+#if INCLUDE_POLY_TOOLKIT
                 data.modelImportCompleted += OnModelImportCompleted;
                 data.thumbnailImportCompleted += OnThumbnailImportCompleted;
+#endif
             }
 
             // Don't scale the item while changing visibility because this would conflict with AnimateVisibility
@@ -406,11 +408,13 @@ namespace UnityEditor.Experimental.EditorVR.Workspaces
             {
                 transform.localScale = Vector3.zero;
             }
+#if INCLUDE_POLY_TOOLKIT
             else
             {
                 data.modelImportCompleted -= OnModelImportCompleted;
                 data.thumbnailImportCompleted -= OnThumbnailImportCompleted;
             }
+#endif
 
             var currentScale = transform.localScale;
             var targetScale = visible ? m_IconScale * scaleFactor : Vector3.zero;


### PR DESCRIPTION
### Purpose of this PR

Take care of a few final details for the 0.3 release

### Testing status

Tested importing this branch and a package made from its contents (plus the imported asmdef patches) into 2017.4 (fails to compile), 2018.4, and 2019.2.

### Technical / Halo risk

Tech Risk (not Tech Correctness, which is deferred to the reviewers)
* **0** could be just zero impact changes, removals but no logic changes
* ### **1** low impact, simple logic changes
* **2** is anything between 1 and 3
* **3** are extremely likely to introduce bugs

Halo Risk (Externality risk)
* **0** local change with no risk to other areas
* ### **1** neighbors could be affected
* **2** anything between 1 and 3
* **3** things might break everywhere]

### Comments to reviewers

The first change set is simple--just wraps some unused events in #if INCLUDE_POLY_TOOLKIT so they don't create warnings if the Poly Toolkit package is not in the project.

My hope in moving `VersionCheck.cs` into its own file was that it would compile even if the main EXR asmdef failed to compile. Unfortunately, this is not the case. Still, I think it is cleaner to have this code in its own file. In an effort to get this to compile, I also ended up removing the reference to EXR in the Utilities/Editor assembly because it was not used.

The other modification to `EditorVR.cs` came up when testing the package import into 2019.2. After the multiple compiles, I found that I had to trigger a manual re-import on the EditorVR script in order for it to get a MonoImporter with the default references set. If we add this "stub" class with just he serialized references, EXR works on first import.

I've also updated `README.md`, created a new copy of the Getting Started Guide, and linked to it. https://docs.google.com/document/d/1Rymrri54MeUO1UE8pev0Tss9dMAcltECOF7NAAO5XuE/edit

You should be able to see what changed in the Getting Started Guide by using Google Docs history. Broad strokes were: remove Undo Patch section, update minimum Unity version, remove steps about importing partner SDKs (🎉)